### PR TITLE
Int 963 rev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,22 @@ FROM php:7.2-apache
 
 ENV WORDPRESS_VERSION=5.3.2
 ENV WOOCOMMERCE_VERSION=3.9.2
-
+ENV TZ Europe/Madrid
 RUN cd /tmp \
     && curl https://es.wordpress.org/wordpress-$WORDPRESS_VERSION-es_ES.tar.gz  -o $WORDPRESS_VERSION-es_ES.tar.gz \
     && tar xf $WORDPRESS_VERSION-es_ES.tar.gz \
     && rm -rf /var/www/html/ \
     && mv wordpress /var/www/html/
 
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 RUN cd /tmp \
     && curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
     && chmod +x wp-cli.phar \
     && mv wp-cli.phar /bin/wp
 
+RUN set -x
 RUN buildDeps="libxml2-dev" \
-    && set -x \
     && apt-get update && apt-get install -y \
         unzip \
         $buildDeps \
@@ -26,7 +28,9 @@ RUN buildDeps="libxml2-dev" \
         libmcrypt-dev \
         pkg-config \
         patch \
-        --no-install-recommends && rm -rf /var/lib/apt/lists/*
+        nano \
+        tree \
+        --no-install-recommends -qq && rm -rf /var/lib/apt/lists/*
 
 #ADD "https://git.archlinux.org/svntogit/packages.git/plain/trunk/freetype.patch?h=packages/php" /tmp/freetype.patch
 #RUN docker-php-source extract; \
@@ -34,10 +38,11 @@ RUN buildDeps="libxml2-dev" \
   #  patch -p1 -i /tmp/freetype.patch; \
    # rm /tmp/freetype.patch
 
-RUN docker-php-ext-install -j$(nproc) pdo_mysql soap mysqli pdo mbstring zip \
-    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install -j$(nproc) gd \
-    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps
+RUN docker-php-ext-install -j$(nproc) pdo_mysql soap mysqli zip > /dev/null \
+    && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ > /dev/null \
+    && docker-php-ext-install -j$(nproc) gd > /dev/null \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false $buildDeps > /dev/null
+
 
 ADD ./config/ /
 RUN chmod +x /*.sh

--- a/WC_Pagantis.php
+++ b/WC_Pagantis.php
@@ -20,13 +20,14 @@ defined('ABSPATH') || exit;
 //formatter:off
 define('PAGANTIS_PLUGIN_ID', 'pagantis');
 define('PG_VERSION', '8.3.8');
-define('PAGANTIS_ROOT_DIR', dirname( __FILE__ ) . '/');         // Root dir.
+define('PAGANTIS_ROOT_DIR', trailingslashit(dirname(__FILE__)));         // Root dir.
 define('PG_WC_MAIN_FILE', __FILE__);
 define('PG_ABSPATH', dirname(PG_WC_MAIN_FILE) . '/');
-define('PG_PLUGIN_URL', untrailingslashit(plugins_url(basename(plugin_dir_path(PG_WC_MAIN_FILE)), basename(PG_WC_MAIN_FILE))));
+define('PG_PLUGIN_URL',
+    untrailingslashit(plugins_url(basename(plugin_dir_path(PG_WC_MAIN_FILE)), basename(PG_WC_MAIN_FILE))));
 define('PG_PLUGIN_PATH', untrailingslashit(plugin_dir_path(PG_WC_MAIN_FILE)));
-define('PG_INCLUDES_PATH', PG_PLUGIN_PATH . '/includes');
-define('PG_TEMPLATE_PATH', PG_PLUGIN_PATH . '/templates/');
+define('PG_INCLUDES_PATH', PAGANTIS_ROOT_DIR . 'includes/');
+define('PG_TEMPLATE_PATH', PAGANTIS_ROOT_DIR . 'templates/');
 define('PG_CART_PROCESSING_TABLE_NAME', 'cart_process');
 define('PG_WC_ORDERS_TABLE_NAME', 'posts');
 define('PG_LOGS_TABLE_NAME', 'pagantis_logs');
@@ -107,7 +108,7 @@ class WcPagantis
         add_filter('plugin_row_meta', array($this, 'pagantisRowMeta'), 10, 2);
         add_filter('plugin_action_links_' . plugin_basename(__FILE__), array($this, 'pagantisActionLinks'));
         add_action('woocommerce_after_add_to_cart_form', array($this, 'pagantisAddProductSimulator'));
-        add_action('wp_enqueue_scripts', array($this, 'add_pagantis_widget_js'));
+        add_action('wp_enqueue_scripts', 'add_pagantis_widget_js');
         add_action('rest_api_init', array($this, 'pagantisRegisterEndpoint')); //Endpoint
         add_filter('load_textdomain_mofile', array($this, 'loadPagantisTranslation'), 10, 2);
         register_activation_hook(__FILE__, array($this, 'pagantisActivation'));
@@ -158,12 +159,12 @@ class WcPagantis
         global $post;
         $_product = get_post_meta($post->ID);
         woocommerce_wp_checkbox(array(
-                'id'      => 'pagantis_promoted',
-                'label'   => __('Pagantis promoted', 'woocommerce'),
-                'value'   => $_product['custom_product_pagantis_promoted']['0'],
-                'cbvalue' => 'yes',
-                'echo'    => true
-            ));
+            'id'      => 'pagantis_promoted',
+            'label'   => __('Pagantis promoted', 'woocommerce'),
+            'value'   => $_product['custom_product_pagantis_promoted']['0'],
+            'cbvalue' => 'yes',
+            'echo'    => true
+        ));
     }
 
     /**
@@ -387,7 +388,7 @@ class WcPagantis
             'productType'               => $product->get_type()
         );
 
-        wc_get_template('product_simulator.php', $template_fields, '', $this->template_path);
+        wc_get_template('product_simulator.php', $template_fields, '', PG_TEMPLATE_PATH);
     }
 
     /**
@@ -597,28 +598,28 @@ class WcPagantis
     public function pagantisRegisterEndpoint()
     {
         register_rest_route('pagantis/v1', '/logs/(?P<secret>\w+)/(?P<from>\d+)/(?P<to>\d+)', array(
-                'methods'  => 'GET',
-                'callback' => array(
-                    $this,
-                    'readLogs'
-                )
-            ), true);
+            'methods'  => 'GET',
+            'callback' => array(
+                $this,
+                'readLogs'
+            )
+        ), true);
 
         register_rest_route('pagantis/v1', '/configController/(?P<secret>\w+)', array(
-                'methods'  => 'GET, POST',
-                'callback' => array(
-                    $this,
-                    'updateExtraConfig'
-                )
-            ), true);
+            'methods'  => 'GET, POST',
+            'callback' => array(
+                $this,
+                'updateExtraConfig'
+            )
+        ), true);
 
         register_rest_route('pagantis/v1', '/api/(?P<secret>\w+)/(?P<from>\w+)/(?P<to>\w+)', array(
-                'methods'  => 'GET',
-                'callback' => array(
-                    $this,
-                    'readApi'
-                )
-            ), true);
+            'methods'  => 'GET',
+            'callback' => array(
+                $this,
+                'readApi'
+            )
+        ), true);
     }
 
     /**
@@ -682,14 +683,15 @@ class WcPagantis
                 && $metaProduct['custom_product_pagantis_promoted']['0'] === 'yes') ? 'true' : 'false';
     }
 
-    /**
-     * Add widget Js
-     **/
-    public function add_pagantis_widget_js()
-    {
-        wp_enqueue_script('pgSDK', 'https://cdn.pagantis.com/js/pg-v2/sdk.js', '', '', true);
-    }
 }
 
 
-$WcPagantis = new WcPagantis();
+/**
+ * Add widget Js
+ **/
+function add_pagantis_widget_js()
+{
+    wp_enqueue_script('pgSDK', 'https://cdn.pagantis.com/js/pg-v2/sdk.js', '', '', true);
+}
+
+new WcPagantis();

--- a/WC_Pagantis.php
+++ b/WC_Pagantis.php
@@ -3,8 +3,9 @@
  * Plugin Name: Pagantis
  * Plugin URI: http://www.pagantis.com/
  * Description: Financiar con Pagantis
- * Version: 8.3.7
+ * Version: 8.3.8
  * Author: Pagantis
+ * Author URI: http://www.pagantis.com/
  *
  * Text Domain: pagantis
  * Domain Path: /languages/
@@ -14,51 +15,73 @@
 //namespace Gateways;
 
 
-if (!defined('ABSPATH')) {
-    exit;
-}
+defined('ABSPATH') || exit;
+
+//formatter:off
+define('PAGANTIS_PLUGIN_ID', 'pagantis');
+define('PG_VERSION', '8.3.8');
+define('PAGANTIS_ROOT_DIR', dirname( __FILE__ ) . '/');         // Root dir.
+define('PG_WC_MAIN_FILE', __FILE__);
+define('PG_ABSPATH', dirname(PG_WC_MAIN_FILE) . '/');
+define('PG_PLUGIN_URL', untrailingslashit(plugins_url(basename(plugin_dir_path(PG_WC_MAIN_FILE)), basename(PG_WC_MAIN_FILE))));
+define('PG_PLUGIN_PATH', untrailingslashit(plugin_dir_path(PG_WC_MAIN_FILE)));
+define('PG_INCLUDES_PATH', PG_PLUGIN_PATH . '/includes');
+define('PG_TEMPLATE_PATH', PG_PLUGIN_PATH . '/templates/');
+define('PG_CART_PROCESSING_TABLE_NAME', 'cart_process');
+define('PG_WC_ORDERS_TABLE_NAME', 'posts');
+define('PG_LOGS_TABLE_NAME', 'pagantis_logs');
+define('PG_DEBUG_LOG_TABLE_NAME', 'pagantis_debug_log');
+define('PG_CONFIG_TABLE_NAME', 'pagantis_config');
+define('PG_CONCURRENCY_TABLE_NAME', 'pagantis_concurrency');
+define('PG_CONCURRENCY_TIMEOUT', '5');
+define('PG_NOT_CONFIRMED_MESSAGE', 'No se ha podido confirmar el pago');
+define('PG_GIT_HUB_URL', 'https://github.com/pagantis/woocommerce');
+define('PG_DOC_URL', 'https://developer.pagantis.com');
+define('PG_SUPPORT_EMAIL', 'mailto:integrations@pagantis.com?Subject=woocommerce_plugin');
+
+//formatter:on
 
 class WcPagantis
 {
-    const GIT_HUB_URL = 'https://github.com/pagantis/woocommerce';
+    const GIT_HUB_URL      = 'https://github.com/pagantis/woocommerce';
     const PAGANTIS_DOC_URL = 'https://developer.pagantis.com';
-    const SUPPORT_EML = 'mailto:integrations@pagantis.com?Subject=woocommerce_plugin';
+    const SUPPORT_EML      = 'mailto:integrations@pagantis.com?Subject=woocommerce_plugin';
 
-    /** Concurrency tablename */
+    /** Concurrency table name */
     const LOGS_TABLE = 'pagantis_logs';
 
-    /** Config tablename */
+    /** Config table name */
     const CONFIG_TABLE = 'pagantis_config';
 
-    /** Concurrency tablename  */
+    /** Concurrency table name  */
     const CONCURRENCY_TABLE = 'pagantis_concurrency';
 
-    /** Config tablename */
+    /** Config table name */
     const ORDERS_TABLE = 'posts';
 
     public $defaultConfigs = array(
-       'PAGANTIS_TITLE'=>'Pago en cuotas',
-       'PAGANTIS_SIMULATOR_DISPLAY_TYPE'=>'sdk.simulator.types.PRODUCT_PAGE',
-       'PAGANTIS_SIMULATOR_DISPLAY_TYPE_CHECKOUT'=>'sdk.simulator.types.CHECKOUT_PAGE',
-       'PAGANTIS_SIMULATOR_DISPLAY_SKIN'=>'sdk.simulator.skins.BLUE',
-       'PAGANTIS_SIMULATOR_DISPLAY_POSITION'=>'hookDisplayProductButtons',
-       'PAGANTIS_SIMULATOR_START_INSTALLMENTS'=>3,
-       'PAGANTIS_SIMULATOR_MAX_INSTALLMENTS'=>12,
-       'PAGANTIS_SIMULATOR_CSS_POSITION_SELECTOR'=>'default',
-       'PAGANTIS_SIMULATOR_DISPLAY_CSS_POSITION'=>'sdk.simulator.positions.INNER',
-       'PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR'=>'a:3:{i:0;s:48:"div.summary *:not(del)>.woocommerce-Price-amount";i:1;s:54:"div.entry-summary *:not(del)>.woocommerce-Price-amount";i:2;s:36:"*:not(del)>.woocommerce-Price-amount";}',
-       'PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR'=>'a:2:{i:0;s:22:"div.quantity input.qty";i:1;s:18:"div.quantity>input";}',
-       'PAGANTIS_FORM_DISPLAY_TYPE'=>0,
-       'PAGANTIS_DISPLAY_MIN_AMOUNT'=>1,
-       'PAGANTIS_DISPLAY_MAX_AMOUNT'=>0,
-       'PAGANTIS_URL_OK'=>'',
-       'PAGANTIS_URL_KO'=>'',
-       'PAGANTIS_ALLOWED_COUNTRIES' => 'a:3:{i:0;s:2:"es";i:1;s:2:"it";i:2;s:2:"fr";}',
-       'PAGANTIS_PROMOTION_EXTRA' => '<p>Finance this product <span class="pg-no-interest">without interest!</span></p>',
-       'PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR' => '.',
-       'PAGANTIS_SIMULATOR_DECIMAL_SEPARATOR' => ',',
-       'PAGANTIS_SIMULATOR_DISPLAY_SITUATION' => 'default',
-       'PAGANTIS_SIMULATOR_SELECTOR_VARIATION' => 'default'
+        'PAGANTIS_TITLE'                           => 'Pago en cuotas',
+        'PAGANTIS_SIMULATOR_DISPLAY_TYPE'          => 'sdk.simulator.types.PRODUCT_PAGE',
+        'PAGANTIS_SIMULATOR_DISPLAY_TYPE_CHECKOUT' => 'sdk.simulator.types.CHECKOUT_PAGE',
+        'PAGANTIS_SIMULATOR_DISPLAY_SKIN'          => 'sdk.simulator.skins.BLUE',
+        'PAGANTIS_SIMULATOR_DISPLAY_POSITION'      => 'hookDisplayProductButtons',
+        'PAGANTIS_SIMULATOR_START_INSTALLMENTS'    => 3,
+        'PAGANTIS_SIMULATOR_MAX_INSTALLMENTS'      => 12,
+        'PAGANTIS_SIMULATOR_CSS_POSITION_SELECTOR' => 'default',
+        'PAGANTIS_SIMULATOR_DISPLAY_CSS_POSITION'  => 'sdk.simulator.positions.INNER',
+        'PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR'    => 'a:3:{i:0;s:48:"div.summary *:not(del)>.woocommerce-Price-amount";i:1;s:54:"div.entry-summary *:not(del)>.woocommerce-Price-amount";i:2;s:36:"*:not(del)>.woocommerce-Price-amount";}',
+        'PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR' => 'a:2:{i:0;s:22:"div.quantity input.qty";i:1;s:18:"div.quantity>input";}',
+        'PAGANTIS_FORM_DISPLAY_TYPE'               => 0,
+        'PAGANTIS_DISPLAY_MIN_AMOUNT'              => 1,
+        'PAGANTIS_DISPLAY_MAX_AMOUNT'              => 0,
+        'PAGANTIS_URL_OK'                          => '',
+        'PAGANTIS_URL_KO'                          => '',
+        'PAGANTIS_ALLOWED_COUNTRIES'               => 'a:3:{i:0;s:2:"es";i:1;s:2:"it";i:2;s:2:"fr";}',
+        'PAGANTIS_PROMOTION_EXTRA'                 => '<p>Finance this product <span class="pg-no-interest">without interest!</span></p>',
+        'PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR'   => '.',
+        'PAGANTIS_SIMULATOR_DECIMAL_SEPARATOR'     => ',',
+        'PAGANTIS_SIMULATOR_DISPLAY_SITUATION'     => 'default',
+        'PAGANTIS_SIMULATOR_SELECTOR_VARIATION'    => 'default'
     );
 
     /** @var Array $extraConfig */
@@ -69,29 +92,29 @@ class WcPagantis
      */
     public function __construct()
     {
-        require_once(plugin_dir_path(__FILE__).'/vendor/autoload.php');
+        require_once(plugin_dir_path(__FILE__) . '/vendor/autoload.php');
 
-        $this->template_path = plugin_dir_path(__FILE__).'/templates/';
+        $this->template_path = plugin_dir_path(__FILE__) . '/templates/';
 
         $this->pagantisActivation();
 
         $this->extraConfig = $this->getExtraConfig();
 
-        load_plugin_textdomain('pagantis', false, dirname(plugin_basename( __FILE__)).'/languages');
+        load_plugin_textdomain('pagantis', false, dirname(plugin_basename(__FILE__)) . '/languages');
 
         add_filter('woocommerce_payment_gateways', array($this, 'addPagantisGateway'));
         add_filter('woocommerce_available_payment_gateways', array($this, 'pagantisFilterGateways'), 9999);
         add_filter('plugin_row_meta', array($this, 'pagantisRowMeta'), 10, 2);
-        add_filter('plugin_action_links_'.plugin_basename(__FILE__), array($this, 'pagantisActionLinks'));
+        add_filter('plugin_action_links_' . plugin_basename(__FILE__), array($this, 'pagantisActionLinks'));
         add_action('woocommerce_after_add_to_cart_form', array($this, 'pagantisAddProductSimulator'));
-        add_action('wp_enqueue_scripts', 'add_pagantis_widget_js');
+        add_action('wp_enqueue_scripts', array($this, 'add_pagantis_widget_js'));
         add_action('rest_api_init', array($this, 'pagantisRegisterEndpoint')); //Endpoint
         add_filter('load_textdomain_mofile', array($this, 'loadPagantisTranslation'), 10, 2);
         register_activation_hook(__FILE__, array($this, 'pagantisActivation'));
         add_action('woocommerce_product_options_general_product_data', array($this, 'pagantisPromotedProductTpl'));
         add_action('woocommerce_process_product_meta', array($this, 'pagantisPromotedVarSave'));
-        add_action('woocommerce_product_bulk_edit_start', array($this,'pagantisPromotedBulkTemplate'));
-        add_action('woocommerce_product_bulk_edit_save', array($this,'pagantisPromotedBulkTemplateSave'));
+        add_action('woocommerce_product_bulk_edit_start', array($this, 'pagantisPromotedBulkTemplate'));
+        add_action('woocommerce_product_bulk_edit_save', array($this, 'pagantisPromotedBulkTemplateSave'));
     }
 
     /**
@@ -111,11 +134,12 @@ class WcPagantis
 
     /**
      * Php code to save our meta after a bulk admin edit
+     *
      * @param $product
      */
     public function pagantisPromotedBulkTemplateSave($product)
     {
-        $post_id = $product->get_id();
+        $post_id                 = $product->get_id();
         $pagantis_promoted_value = $_REQUEST['pagantis_promoted'];
         if ($pagantis_promoted_value == 'on') {
             $pagantis_promoted_value = 'yes';
@@ -133,19 +157,18 @@ class WcPagantis
     {
         global $post;
         $_product = get_post_meta($post->ID);
-        woocommerce_wp_checkbox(
-            array(
-                'id' => 'pagantis_promoted',
-                'label' => __('Pagantis promoted', 'woocommerce'),
-                'value' => $_product['custom_product_pagantis_promoted']['0'],
+        woocommerce_wp_checkbox(array(
+                'id'      => 'pagantis_promoted',
+                'label'   => __('Pagantis promoted', 'woocommerce'),
+                'value'   => $_product['custom_product_pagantis_promoted']['0'],
                 'cbvalue' => 'yes',
-                'echo' => true
-            )
-        );
+                'echo'    => true
+            ));
     }
 
     /**
      *  Php code to save our meta after a PRODUCT admin edit
+     *
      * @param $post_id
      */
     public function pagantisPromotedVarSave($post_id)
@@ -167,6 +190,7 @@ class WcPagantis
         if ('pagantis' === $domain) {
             $mofile = WP_LANG_DIR . '/../plugins/pagantis/languages/pagantis-' . get_locale() . '.mo';
         }
+
         return $mofile;
     }
 
@@ -177,32 +201,33 @@ class WcPagantis
     {
         global $wpdb;
 
-        $tableName = $wpdb->prefix.self::CONCURRENCY_TABLE;
+        $tableName = $wpdb->prefix . self::CONCURRENCY_TABLE;
         if ($wpdb->get_var("SHOW TABLES LIKE '$tableName'") != $tableName) {
             $charset_collate = $wpdb->get_charset_collate();
-            $sql = "CREATE TABLE $tableName ( order_id int NOT NULL,  
+            $sql             = "CREATE TABLE $tableName ( order_id int NOT NULL,  
                     createdAt timestamp DEFAULT CURRENT_TIMESTAMP, UNIQUE KEY id (order_id)) $charset_collate";
-            require_once(ABSPATH.'wp-admin/includes/upgrade.php');
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
             dbDelta($sql);
         }
 
-        $tableName = $wpdb->prefix.self::CONFIG_TABLE;
+        $tableName = $wpdb->prefix . self::CONFIG_TABLE;
 
         //Check if table exists
         $tableExists = $wpdb->get_var("SHOW TABLES LIKE '$tableName'") != $tableName;
         if ($tableExists) {
             $charset_collate = $wpdb->get_charset_collate();
-            $sql = "CREATE TABLE IF NOT EXISTS $tableName (
+            $sql             = "CREATE TABLE IF NOT EXISTS $tableName (
                                 id int NOT NULL AUTO_INCREMENT, 
                                 config varchar(60) NOT NULL, 
                                 value varchar(1000) NOT NULL, 
                                 UNIQUE KEY id(id)) $charset_collate";
 
-            require_once(ABSPATH.'wp-admin/includes/upgrade.php');
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
             dbDelta($sql);
         } else {
             //Updated value field to adapt to new length < v8.0.1
-            $query = "select COLUMN_TYPE FROM information_schema.COLUMNS where TABLE_NAME='$tableName' AND COLUMN_NAME='value'";
+            $query   =
+                "select COLUMN_TYPE FROM information_schema.COLUMNS where TABLE_NAME='$tableName' AND COLUMN_NAME='value'";
             $results = $wpdb->get_results($query, ARRAY_A);
             if ($results['0']['COLUMN_TYPE'] == 'varchar(100)') {
                 $sql = "ALTER TABLE $tableName MODIFY value varchar(1000)";
@@ -210,78 +235,80 @@ class WcPagantis
             }
 
             //Adapting selector to array < v8.1.1
-            $query = "select * from $tableName where config='PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR' 
+            $query           = "select * from $tableName where config='PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR' 
                                or config='PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR'";
             $dbCurrentConfig = $wpdb->get_results($query, ARRAY_A);
             foreach ($dbCurrentConfig as $item) {
                 if ($item['config'] == 'PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR') {
                     $css_price_selector = $this->preparePriceSelector($item['value']);
                     if ($item['value'] != $css_price_selector) {
-                        $wpdb->update(
-                            $tableName,
-                            array('value' => stripslashes($css_price_selector)),
-                            array('config' => 'PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR'),
-                            array('%s'),
-                            array('%s')
-                        );
+                        $wpdb->update($tableName, array('value' => stripslashes($css_price_selector)),
+                            array('config' => 'PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR'), array('%s'), array('%s'));
                     }
                 } elseif ($item['config'] == 'PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR') {
                     $css_quantity_selector = $this->prepareQuantitySelector($item['value']);
                     if ($item['value'] != $css_quantity_selector) {
-                        $wpdb->update(
-                            $tableName,
-                            array('value' => stripslashes($css_quantity_selector)),
-                            array('config' => 'PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR'),
-                            array('%s'),
-                            array('%s')
-                        );
+                        $wpdb->update($tableName, array('value' => stripslashes($css_quantity_selector)),
+                            array('config' => 'PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR'), array('%s'), array('%s'));
                     }
                 }
             }
         }
 
         //Adapting selector to array < v8.2.2
-        $tableName = $wpdb->prefix.self::CONFIG_TABLE;
-        $query = "select * from $tableName where config='PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR'";
-        $results = $wpdb->get_results($query, ARRAY_A);
+        $tableName = $wpdb->prefix . self::CONFIG_TABLE;
+        $query     = "select * from $tableName where config='PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR'";
+        $results   = $wpdb->get_results($query, ARRAY_A);
         if (count($results) == 0) {
-            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR', 'value'  => '.'), array('%s', '%s'));
-            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_DECIMAL_SEPARATOR', 'value'  => ','), array('%s', '%s'));
+            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR', 'value' => '.'),
+                array('%s', '%s'));
+            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_DECIMAL_SEPARATOR', 'value' => ','),
+                array('%s', '%s'));
         }
 
         //Adding new selector < v8.3.0
-        $tableName = $wpdb->prefix.self::CONFIG_TABLE;
-        $query = "select * from $tableName where config='PAGANTIS_DISPLAY_MAX_AMOUNT'";
-        $results = $wpdb->get_results($query, ARRAY_A);
+        $tableName = $wpdb->prefix . self::CONFIG_TABLE;
+        $query     = "select * from $tableName where config='PAGANTIS_DISPLAY_MAX_AMOUNT'";
+        $results   = $wpdb->get_results($query, ARRAY_A);
         if (count($results) == 0) {
-            $wpdb->insert($tableName, array('config' => 'PAGANTIS_DISPLAY_MAX_AMOUNT', 'value'  => '0'), array('%s', '%s'));
+            $wpdb->insert($tableName, array('config' => 'PAGANTIS_DISPLAY_MAX_AMOUNT', 'value' => '0'),
+                array('%s', '%s'));
         }
 
         //Adding new selector < v8.3.2
-        $tableName = $wpdb->prefix.self::CONFIG_TABLE;
-        $query = "select * from $tableName where config='PAGANTIS_SIMULATOR_DISPLAY_SITUATION'";
-        $results = $wpdb->get_results($query, ARRAY_A);
+        $tableName = $wpdb->prefix . self::CONFIG_TABLE;
+        $query     = "select * from $tableName where config='PAGANTIS_SIMULATOR_DISPLAY_SITUATION'";
+        $results   = $wpdb->get_results($query, ARRAY_A);
         if (count($results) == 0) {
-            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_DISPLAY_SITUATION', 'value'  => 'default'), array('%s', '%s'));
-            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_SELECTOR_VARIATION', 'value'  => 'default'), array('%s', '%s'));
+            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_DISPLAY_SITUATION', 'value' => 'default'),
+                array('%s', '%s'));
+            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_SELECTOR_VARIATION', 'value' => 'default'),
+                array('%s', '%s'));
         }
 
         //Adding new selector < v8.3.3
-        $tableName = $wpdb->prefix.self::CONFIG_TABLE;
-        $query = "select * from $tableName where config='PAGANTIS_SIMULATOR_DISPLAY_TYPE_CHECKOUT'";
-        $results = $wpdb->get_results($query, ARRAY_A);
+        $tableName = $wpdb->prefix . self::CONFIG_TABLE;
+        $query     = "select * from $tableName where config='PAGANTIS_SIMULATOR_DISPLAY_TYPE_CHECKOUT'";
+        $results   = $wpdb->get_results($query, ARRAY_A);
         if (count($results) == 0) {
-            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_DISPLAY_TYPE_CHECKOUT', 'value'  => 'sdk.simulator.types.CHECKOUT_PAGE'), array('%s', '%s'));
-            $wpdb->update($tableName, array('value' => 'sdk.simulator.types.PRODUCT_PAGE'), array('config' => 'PAGANTIS_SIMULATOR_DISPLAY_TYPE'), array('%s'), array('%s'));
+            $wpdb->insert($tableName, array(
+                'config' => 'PAGANTIS_SIMULATOR_DISPLAY_TYPE_CHECKOUT',
+                'value'  => 'sdk.simulator.types.CHECKOUT_PAGE'
+            ), array('%s', '%s'));
+            $wpdb->update($tableName, array('value' => 'sdk.simulator.types.PRODUCT_PAGE'),
+                array('config' => 'PAGANTIS_SIMULATOR_DISPLAY_TYPE'), array('%s'), array('%s'));
         }
 
         //Adapting to variable selector < v8.3.6
-        $variableSelector="div.summary div.woocommerce-variation.single_variation > div.woocommerce-variation-price span.price";
-        $tableName = $wpdb->prefix.self::CONFIG_TABLE;
-        $query = "select * from $tableName where config='PAGANTIS_SIMULATOR_SELECTOR_VARIATION' and value='default'";
-        $results = $wpdb->get_results($query, ARRAY_A);
+        $variableSelector =
+            "div.summary div.woocommerce-variation.single_variation > div.woocommerce-variation-price span.price";
+        $tableName        = $wpdb->prefix . self::CONFIG_TABLE;
+        $query            =
+            "select * from $tableName where config='PAGANTIS_SIMULATOR_SELECTOR_VARIATION' and value='default'";
+        $results          = $wpdb->get_results($query, ARRAY_A);
         if (count($results) == 0) {
-            $wpdb->update($tableName, array('value' => $variableSelector), array('config' => 'PAGANTIS_SIMULATOR_SELECTOR_VARIATION'), array('%s'), array('%s'));
+            $wpdb->update($tableName, array('value' => $variableSelector),
+                array('config' => 'PAGANTIS_SIMULATOR_SELECTOR_VARIATION'), array('%s'), array('%s'));
         }
 
         $dbConfigs = $wpdb->get_results("select * from $tableName", ARRAY_A);
@@ -292,21 +319,21 @@ class WcPagantis
             $simpleDbConfigs[$config['config']] = $config['value'];
         }
         $newConfigs = array_diff_key($this->defaultConfigs, $simpleDbConfigs);
-        if (!empty($newConfigs)) {
+        if ( ! empty($newConfigs)) {
             foreach ($newConfigs as $key => $value) {
-                $wpdb->insert($tableName, array('config' => $key, 'value'  => $value), array('%s', '%s'));
+                $wpdb->insert($tableName, array('config' => $key, 'value' => $value), array('%s', '%s'));
             }
         }
 
         //Current plugin config: pagantis_public_key => New field --- public_key => Old field
         $settings = get_option('woocommerce_pagantis_settings');
 
-        if (!isset($settings['pagantis_public_key']) && $settings['public_key']) {
+        if ( ! isset($settings['pagantis_public_key']) && $settings['public_key']) {
             $settings['pagantis_public_key'] = $settings['public_key'];
             unset($settings['public_key']);
         }
 
-        if (!isset($settings['pagantis_private_key']) && $settings['secret_key']) {
+        if ( ! isset($settings['pagantis_private_key']) && $settings['secret_key']) {
             $settings['pagantis_private_key'] = $settings['secret_key'];
             unset($settings['secret_key']);
         }
@@ -321,40 +348,43 @@ class WcPagantis
     {
         global $product;
 
-        $cfg = get_option('woocommerce_pagantis_settings');
-        $locale = strtolower(strstr(get_locale(), '_', true));
+        $cfg              = get_option('woocommerce_pagantis_settings');
+        $locale           = strtolower(strstr(get_locale(), '_', true));
         $allowedCountries = unserialize($this->extraConfig['PAGANTIS_ALLOWED_COUNTRIES']);
-        $allowedCountry = (in_array(strtolower($locale), $allowedCountries));
-        $minAmount = $this->extraConfig['PAGANTIS_DISPLAY_MIN_AMOUNT'];
-        $maxAmount = $this->extraConfig['PAGANTIS_DISPLAY_MAX_AMOUNT'];
-        $totalPrice = $product->get_price();
-        $validAmount = ($totalPrice>=$minAmount && ($totalPrice<=$maxAmount || $maxAmount=='0'));
-        if ($cfg['enabled'] !== 'yes' || $cfg['pagantis_public_key'] == '' || $cfg['pagantis_private_key'] == '' ||
-            $cfg['simulator'] !== 'yes'  || !$allowedCountry || !$validAmount) {
+        $allowedCountry   = (in_array(strtolower($locale), $allowedCountries));
+        $minAmount        = $this->extraConfig['PAGANTIS_DISPLAY_MIN_AMOUNT'];
+        $maxAmount        = $this->extraConfig['PAGANTIS_DISPLAY_MAX_AMOUNT'];
+        $totalPrice       = $product->get_price();
+        $validAmount      = ($totalPrice >= $minAmount && ($totalPrice <= $maxAmount || $maxAmount == '0'));
+        if ($cfg['enabled'] !== 'yes' || $cfg['pagantis_public_key'] == '' || $cfg['pagantis_private_key'] == ''
+            || $cfg['simulator'] !== 'yes'
+            || ! $allowedCountry
+            || ! $validAmount
+        ) {
             return;
         }
 
-        $post_id = $product->get_id();
+        $post_id         = $product->get_id();
         $template_fields = array(
-            'total'    => is_numeric($product->get_price()) ? $product->get_price() : 0,
-            'public_key' => $cfg['pagantis_public_key'],
-            'simulator_type' => $this->extraConfig['PAGANTIS_SIMULATOR_DISPLAY_TYPE'],
-            'positionSelector' => $this->extraConfig['PAGANTIS_SIMULATOR_CSS_POSITION_SELECTOR'],
-            'quantitySelector' => unserialize($this->extraConfig['PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR']),
-            'priceSelector' => unserialize($this->extraConfig['PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR']),
-            'totalAmount' => is_numeric($product->get_price()) ? $product->get_price() : 0,
-            'locale' => $locale,
-            'country' => $locale,
-            'promoted' => $this->isPromoted($post_id),
-            'promotedMessage' => $this->extraConfig['PAGANTIS_PROMOTION_EXTRA'],
-            'thousandSeparator' => $this->extraConfig['PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR'],
-            'decimalSeparator' => $this->extraConfig['PAGANTIS_SIMULATOR_DECIMAL_SEPARATOR'],
-            'pagantisQuotesStart' => $this->extraConfig['PAGANTIS_SIMULATOR_START_INSTALLMENTS'],
-            'pagantisSimulatorSkin' => $this->extraConfig['PAGANTIS_SIMULATOR_DISPLAY_SKIN'],
+            'total'                     => is_numeric($product->get_price()) ? $product->get_price() : 0,
+            'public_key'                => $cfg['pagantis_public_key'],
+            'simulator_type'            => $this->extraConfig['PAGANTIS_SIMULATOR_DISPLAY_TYPE'],
+            'positionSelector'          => $this->extraConfig['PAGANTIS_SIMULATOR_CSS_POSITION_SELECTOR'],
+            'quantitySelector'          => unserialize($this->extraConfig['PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR']),
+            'priceSelector'             => unserialize($this->extraConfig['PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR']),
+            'totalAmount'               => is_numeric($product->get_price()) ? $product->get_price() : 0,
+            'locale'                    => $locale,
+            'country'                   => $locale,
+            'promoted'                  => $this->isPromoted($post_id),
+            'promotedMessage'           => $this->extraConfig['PAGANTIS_PROMOTION_EXTRA'],
+            'thousandSeparator'         => $this->extraConfig['PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR'],
+            'decimalSeparator'          => $this->extraConfig['PAGANTIS_SIMULATOR_DECIMAL_SEPARATOR'],
+            'pagantisQuotesStart'       => $this->extraConfig['PAGANTIS_SIMULATOR_START_INSTALLMENTS'],
+            'pagantisSimulatorSkin'     => $this->extraConfig['PAGANTIS_SIMULATOR_DISPLAY_SKIN'],
             'pagantisSimulatorPosition' => $this->extraConfig['PAGANTIS_SIMULATOR_DISPLAY_CSS_POSITION'],
-            'finalDestination' => $this->extraConfig['PAGANTIS_SIMULATOR_DISPLAY_SITUATION'],
-            'variationSelector' => $this->extraConfig['PAGANTIS_SIMULATOR_SELECTOR_VARIATION'],
-            'productType' => $product->get_type()
+            'finalDestination'          => $this->extraConfig['PAGANTIS_SIMULATOR_DISPLAY_SITUATION'],
+            'variationSelector'         => $this->extraConfig['PAGANTIS_SIMULATOR_SELECTOR_VARIATION'],
+            'productType'               => $product->get_type()
         );
 
         wc_get_template('product_simulator.php', $template_fields, '', $this->template_path);
@@ -369,7 +399,7 @@ class WcPagantis
      */
     public function addPagantisGateway($methods)
     {
-        if (! class_exists('WC_Payment_Gateway')) {
+        if ( ! class_exists('WC_Payment_Gateway')) {
             return $methods;
         }
 
@@ -389,7 +419,7 @@ class WcPagantis
     public function pagantisFilterGateways($methods)
     {
         $pagantis = new WcPagantisGateway();
-        if (!$pagantis->is_available()) {
+        if ( ! $pagantis->is_available()) {
             unset($methods['pagantis']);
         }
 
@@ -407,7 +437,7 @@ class WcPagantis
     {
         $params_array = array('page' => 'wc-settings', 'tab' => 'checkout', 'section' => 'pagantis');
         $setting_url  = esc_url(add_query_arg($params_array, admin_url('admin.php?')));
-        $setting_link = '<a href="'.$setting_url.'">'.__('Settings', 'pagantis').'</a>';
+        $setting_link = '<a href="' . $setting_url . '">' . __('Settings', 'pagantis') . '</a>';
 
         array_unshift($links, $setting_link);
 
@@ -425,10 +455,12 @@ class WcPagantis
     public function pagantisRowMeta($links, $file)
     {
         if ($file == plugin_basename(__FILE__)) {
-            $links[] = '<a href="'.WcPagantis::GIT_HUB_URL.'" target="_blank">'.__('Documentation', 'pagantis').'</a>';
-            $links[] = '<a href="'.WcPagantis::PAGANTIS_DOC_URL.'" target="_blank">'.
-                       __('API documentation', 'pagantis').'</a>';
-            $links[] = '<a href="'.WcPagantis::SUPPORT_EML.'">'.__('Support', 'pagantis').'</a>';
+            $links[] =
+                '<a href="' . WcPagantis::GIT_HUB_URL . '" target="_blank">' . __('Documentation', 'pagantis') . '</a>';
+            $links[] =
+                '<a href="' . WcPagantis::PAGANTIS_DOC_URL . '" target="_blank">' . __('API documentation', 'pagantis')
+                . '</a>';
+            $links[] = '<a href="' . WcPagantis::SUPPORT_EML . '">' . __('Support', 'pagantis') . '</a>';
 
             return $links;
         }
@@ -442,16 +474,16 @@ class WcPagantis
     public function readLogs($data)
     {
         global $wpdb;
-        $filters   = ($data->get_params());
-        $response  = array();
-        $secretKey = $filters['secret'];
-        $from = $filters['from'];
-        $to   = $filters['to'];
-        $cfg  = get_option('woocommerce_pagantis_settings');
+        $filters    = ($data->get_params());
+        $response   = array();
+        $secretKey  = $filters['secret'];
+        $from       = $filters['from'];
+        $to         = $filters['to'];
+        $cfg        = get_option('woocommerce_pagantis_settings');
         $privateKey = isset($cfg['pagantis_private_key']) ? $cfg['pagantis_private_key'] : null;
-        $tableName = $wpdb->prefix.self::LOGS_TABLE;
-        $query = "select * from $tableName where createdAt>$from and createdAt<$to order by createdAt desc";
-        $results = $wpdb->get_results($query);
+        $tableName  = $wpdb->prefix . self::LOGS_TABLE;
+        $query      = "select * from $tableName where createdAt>$from and createdAt<$to order by createdAt desc";
+        $results    = $wpdb->get_results($query);
         if (isset($results) && $privateKey == $secretKey) {
             foreach ($results as $key => $result) {
                 $response[$key]['timestamp'] = $result->createdAt;
@@ -463,7 +495,7 @@ class WcPagantis
         $response = json_encode($response);
         header("HTTP/1.1 200", true, 200);
         header('Content-Type: application/json', true);
-        header('Content-Length: '.strlen($response));
+        header('Content-Length: ' . strlen($response));
         echo($response);
         exit();
     }
@@ -474,12 +506,12 @@ class WcPagantis
     public function updateExtraConfig($data)
     {
         global $wpdb;
-        $tableName = $wpdb->prefix.self::CONFIG_TABLE;
-        $response = array('status'=>null);
+        $tableName = $wpdb->prefix . self::CONFIG_TABLE;
+        $response  = array('status' => null);
 
-        $filters   = ($data->get_params());
-        $secretKey = $filters['secret'];
-        $cfg  = get_option('woocommerce_pagantis_settings');
+        $filters    = ($data->get_params());
+        $secretKey  = $filters['secret'];
+        $cfg        = get_option('woocommerce_pagantis_settings');
         $privateKey = isset($cfg['pagantis_private_key']) ? $cfg['pagantis_private_key'] : null;
         if ($privateKey != $secretKey) {
             $response['status'] = 401;
@@ -487,14 +519,9 @@ class WcPagantis
         } elseif ($_SERVER['REQUEST_METHOD'] == 'POST') {
             if (count($_POST)) {
                 foreach ($_POST as $config => $value) {
-                    if (isset($this->defaultConfigs[$config]) && $response['status']==null) {
-                        $wpdb->update(
-                            $tableName,
-                            array('value' => stripslashes($value)),
-                            array('config' => $config),
-                            array('%s'),
-                            array('%s')
-                        );
+                    if (isset($this->defaultConfigs[$config]) && $response['status'] == null) {
+                        $wpdb->update($tableName, array('value' => stripslashes($value)), array('config' => $config),
+                            array('%s'), array('%s'));
                     } else {
                         $response['status'] = 400;
                         $response['result'] = 'Bad request';
@@ -506,9 +533,9 @@ class WcPagantis
             }
         }
 
-        if ($response['status']==null) {
-            $tableName = $wpdb->prefix.self::CONFIG_TABLE;
-            $dbResult = $wpdb->get_results("select config, value from $tableName", ARRAY_A);
+        if ($response['status'] == null) {
+            $tableName = $wpdb->prefix . self::CONFIG_TABLE;
+            $dbResult  = $wpdb->get_results("select config, value from $tableName", ARRAY_A);
             foreach ($dbResult as $value) {
                 $formattedResult[$value['config']] = $value['value'];
             }
@@ -516,9 +543,9 @@ class WcPagantis
         }
 
         $result = json_encode($response['result']);
-        header("HTTP/1.1 ".$response['status'], true, $response['status']);
+        header("HTTP/1.1 " . $response['status'], true, $response['status']);
         header('Content-Type: application/json', true);
-        header('Content-Length: '.strlen($result));
+        header('Content-Length: ' . strlen($result));
         echo($result);
         exit();
     }
@@ -529,26 +556,26 @@ class WcPagantis
     public function readApi($data)
     {
         global $wpdb;
-        $filters   = ($data->get_params());
-        $response  = array('timestamp'=>time());
-        $secretKey = $filters['secret'];
-        $from = ($filters['from']) ? date_create($filters['from']) : date("Y-m-d", strtotime("-7 day"));
-        $to = ($filters['to']) ? date_create($filters['to']) : date("Y-m-d", strtotime("+1 day"));
-        $method = ($filters['method']) ? ($filters['method']) : 'Pagantis';
-        $cfg  = get_option('woocommerce_pagantis_settings');
-        $privateKey = isset($cfg['pagantis_private_key']) ? $cfg['pagantis_private_key'] : null;
-        $tableName = $wpdb->prefix.self::ORDERS_TABLE;
-        $tableNameInner = $wpdb->prefix.'postmeta';
-        $query = "select * from $tableName tn INNER JOIN $tableNameInner tn2 ON tn2.post_id = tn.id
-                  where tn.post_type='shop_order' and tn.post_date>'".$from->format("Y-m-d")."' 
-                  and tn.post_date<'".$to->format("Y-m-d")."' order by tn.post_date desc";
-        $results = $wpdb->get_results($query);
+        $filters        = ($data->get_params());
+        $response       = array('timestamp' => time());
+        $secretKey      = $filters['secret'];
+        $from           = ($filters['from']) ? date_create($filters['from']) : date("Y-m-d", strtotime("-7 day"));
+        $to             = ($filters['to']) ? date_create($filters['to']) : date("Y-m-d", strtotime("+1 day"));
+        $method         = ($filters['method']) ? ($filters['method']) : 'Pagantis';
+        $cfg            = get_option('woocommerce_pagantis_settings');
+        $privateKey     = isset($cfg['pagantis_private_key']) ? $cfg['pagantis_private_key'] : null;
+        $tableName      = $wpdb->prefix . self::ORDERS_TABLE;
+        $tableNameInner = $wpdb->prefix . 'postmeta';
+        $query          = "select * from $tableName tn INNER JOIN $tableNameInner tn2 ON tn2.post_id = tn.id
+                  where tn.post_type='shop_order' and tn.post_date>'" . $from->format("Y-m-d") . "' 
+                  and tn.post_date<'" . $to->format("Y-m-d") . "' order by tn.post_date desc";
+        $results        = $wpdb->get_results($query);
 
         if (isset($results) && $privateKey == $secretKey) {
             foreach ($results as $result) {
-                $key = $result->ID;
-                $response['message'][$key]['timestamp'] = $result->post_date;
-                $response['message'][$key]['order_id'] = $key;
+                $key                                          = $result->ID;
+                $response['message'][$key]['timestamp']       = $result->post_date;
+                $response['message'][$key]['order_id']        = $key;
                 $response['message'][$key][$result->meta_key] = $result->meta_value;
             }
         } else {
@@ -557,52 +584,41 @@ class WcPagantis
         $response = json_encode($response);
         header("HTTP/1.1 200", true, 200);
         header('Content-Type: application/json', true);
-        header('Content-Length: '.strlen($response));
+        header('Content-Length: ' . strlen($response));
         echo($response);
         exit();
     }
 
     /**
      * ENDPOINT - Read logs -> Hook: rest_api_init
+     *
      * @return mixed
      */
     public function pagantisRegisterEndpoint()
     {
-        register_rest_route(
-            'pagantis/v1',
-            '/logs/(?P<secret>\w+)/(?P<from>\d+)/(?P<to>\d+)',
-            array(
+        register_rest_route('pagantis/v1', '/logs/(?P<secret>\w+)/(?P<from>\d+)/(?P<to>\d+)', array(
                 'methods'  => 'GET',
                 'callback' => array(
                     $this,
-                    'readLogs')
-            ),
-            true
-        );
+                    'readLogs'
+                )
+            ), true);
 
-        register_rest_route(
-            'pagantis/v1',
-            '/configController/(?P<secret>\w+)',
-            array(
+        register_rest_route('pagantis/v1', '/configController/(?P<secret>\w+)', array(
                 'methods'  => 'GET, POST',
                 'callback' => array(
                     $this,
-                    'updateExtraConfig')
-            ),
-            true
-        );
+                    'updateExtraConfig'
+                )
+            ), true);
 
-        register_rest_route(
-            'pagantis/v1',
-            '/api/(?P<secret>\w+)/(?P<from>\w+)/(?P<to>\w+)',
-            array(
+        register_rest_route('pagantis/v1', '/api/(?P<secret>\w+)/(?P<from>\w+)/(?P<to>\w+)', array(
                 'methods'  => 'GET',
                 'callback' => array(
                     $this,
-                    'readApi')
-            ),
-            true
-        );
+                    'readApi'
+                )
+            ), true);
     }
 
     /**
@@ -611,9 +627,9 @@ class WcPagantis
     private function getExtraConfig()
     {
         global $wpdb;
-        $tableName = $wpdb->prefix.self::CONFIG_TABLE;
-        $response = array();
-        $dbResult = $wpdb->get_results("select config, value from $tableName", ARRAY_A);
+        $tableName = $wpdb->prefix . self::CONFIG_TABLE;
+        $response  = array();
+        $dbResult  = $wpdb->get_results("select config, value from $tableName", ARRAY_A);
         foreach ($dbResult as $value) {
             $response[$value['config']] = $value['value'];
         }
@@ -630,7 +646,7 @@ class WcPagantis
     {
         if ($css_quantity_selector == 'default' || $css_quantity_selector == '') {
             $css_quantity_selector = $this->defaultConfigs['PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR'];
-        } elseif (!unserialize($css_quantity_selector)) { //in the case of a custom string selector, we keep it
+        } elseif ( ! unserialize($css_quantity_selector)) { //in the case of a custom string selector, we keep it
             $css_quantity_selector = serialize(array($css_quantity_selector));
         }
 
@@ -646,7 +662,7 @@ class WcPagantis
     {
         if ($css_price_selector == 'default' || $css_price_selector == '') {
             $css_price_selector = $this->defaultConfigs['PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR'];
-        } elseif (!unserialize($css_price_selector)) { //in the case of a custom string selector, we keep it
+        } elseif ( ! unserialize($css_price_selector)) { //in the case of a custom string selector, we keep it
             $css_price_selector = serialize(array($css_price_selector));
         }
 
@@ -661,17 +677,19 @@ class WcPagantis
     private function isPromoted($product_id)
     {
         $metaProduct = get_post_meta($product_id);
-        return (array_key_exists('custom_product_pagantis_promoted', $metaProduct) &&
-                $metaProduct['custom_product_pagantis_promoted']['0'] === 'yes') ? 'true' : 'false';
+
+        return (array_key_exists('custom_product_pagantis_promoted', $metaProduct)
+                && $metaProduct['custom_product_pagantis_promoted']['0'] === 'yes') ? 'true' : 'false';
+    }
+
+    /**
+     * Add widget Js
+     **/
+    public function add_pagantis_widget_js()
+    {
+        wp_enqueue_script('pgSDK', 'https://cdn.pagantis.com/js/pg-v2/sdk.js', '', '', true);
     }
 }
 
-/**
- * Add widget Js
- **/
-function add_pagantis_widget_js()
-{
-    wp_enqueue_script('pgSDK', 'https://cdn.pagantis.com/js/pg-v2/sdk.js', '', '', true);
-}
 
 $WcPagantis = new WcPagantis();

--- a/WC_Pagantis.php
+++ b/WC_Pagantis.php
@@ -23,8 +23,10 @@ define('PG_VERSION', '8.3.8');
 define('PAGANTIS_ROOT_DIR', trailingslashit(dirname(__FILE__)));         // Root dir.
 define('PG_WC_MAIN_FILE', __FILE__);
 define('PG_ABSPATH', dirname(PG_WC_MAIN_FILE) . '/');
-define('PG_PLUGIN_URL',
-    untrailingslashit(plugins_url(basename(plugin_dir_path(PG_WC_MAIN_FILE)), basename(PG_WC_MAIN_FILE))));
+define(
+    'PG_PLUGIN_URL',
+    untrailingslashit(plugins_url(basename(plugin_dir_path(PG_WC_MAIN_FILE)), basename(PG_WC_MAIN_FILE)))
+);
 define('PG_PLUGIN_PATH', untrailingslashit(plugin_dir_path(PG_WC_MAIN_FILE)));
 define('PG_INCLUDES_PATH', PAGANTIS_ROOT_DIR . 'includes/');
 define('PG_TEMPLATE_PATH', PAGANTIS_ROOT_DIR . 'templates/');
@@ -243,14 +245,24 @@ class WcPagantis
                 if ($item['config'] == 'PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR') {
                     $css_price_selector = $this->preparePriceSelector($item['value']);
                     if ($item['value'] != $css_price_selector) {
-                        $wpdb->update($tableName, array('value' => stripslashes($css_price_selector)),
-                            array('config' => 'PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR'), array('%s'), array('%s'));
+                        $wpdb->update(
+                            $tableName,
+                            array('value' => stripslashes($css_price_selector)),
+                            array('config' => 'PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR'),
+                            array('%s'),
+                            array('%s')
+                        );
                     }
                 } elseif ($item['config'] == 'PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR') {
                     $css_quantity_selector = $this->prepareQuantitySelector($item['value']);
                     if ($item['value'] != $css_quantity_selector) {
-                        $wpdb->update($tableName, array('value' => stripslashes($css_quantity_selector)),
-                            array('config' => 'PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR'), array('%s'), array('%s'));
+                        $wpdb->update(
+                            $tableName,
+                            array('value' => stripslashes($css_quantity_selector)),
+                            array('config' => 'PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR'),
+                            array('%s'),
+                            array('%s')
+                        );
                     }
                 }
             }
@@ -261,10 +273,16 @@ class WcPagantis
         $query     = "select * from $tableName where config='PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR'";
         $results   = $wpdb->get_results($query, ARRAY_A);
         if (count($results) == 0) {
-            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR', 'value' => '.'),
-                array('%s', '%s'));
-            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_DECIMAL_SEPARATOR', 'value' => ','),
-                array('%s', '%s'));
+            $wpdb->insert(
+                $tableName,
+                array('config' => 'PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR', 'value' => '.'),
+                array('%s', '%s')
+            );
+            $wpdb->insert(
+                $tableName,
+                array('config' => 'PAGANTIS_SIMULATOR_DECIMAL_SEPARATOR', 'value' => ','),
+                array('%s', '%s')
+            );
         }
 
         //Adding new selector < v8.3.0
@@ -272,8 +290,11 @@ class WcPagantis
         $query     = "select * from $tableName where config='PAGANTIS_DISPLAY_MAX_AMOUNT'";
         $results   = $wpdb->get_results($query, ARRAY_A);
         if (count($results) == 0) {
-            $wpdb->insert($tableName, array('config' => 'PAGANTIS_DISPLAY_MAX_AMOUNT', 'value' => '0'),
-                array('%s', '%s'));
+            $wpdb->insert(
+                $tableName,
+                array('config' => 'PAGANTIS_DISPLAY_MAX_AMOUNT', 'value' => '0'),
+                array('%s', '%s')
+            );
         }
 
         //Adding new selector < v8.3.2
@@ -281,10 +302,16 @@ class WcPagantis
         $query     = "select * from $tableName where config='PAGANTIS_SIMULATOR_DISPLAY_SITUATION'";
         $results   = $wpdb->get_results($query, ARRAY_A);
         if (count($results) == 0) {
-            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_DISPLAY_SITUATION', 'value' => 'default'),
-                array('%s', '%s'));
-            $wpdb->insert($tableName, array('config' => 'PAGANTIS_SIMULATOR_SELECTOR_VARIATION', 'value' => 'default'),
-                array('%s', '%s'));
+            $wpdb->insert(
+                $tableName,
+                array('config' => 'PAGANTIS_SIMULATOR_DISPLAY_SITUATION', 'value' => 'default'),
+                array('%s', '%s')
+            );
+            $wpdb->insert(
+                $tableName,
+                array('config' => 'PAGANTIS_SIMULATOR_SELECTOR_VARIATION', 'value' => 'default'),
+                array('%s', '%s')
+            );
         }
 
         //Adding new selector < v8.3.3
@@ -296,8 +323,13 @@ class WcPagantis
                 'config' => 'PAGANTIS_SIMULATOR_DISPLAY_TYPE_CHECKOUT',
                 'value'  => 'sdk.simulator.types.CHECKOUT_PAGE'
             ), array('%s', '%s'));
-            $wpdb->update($tableName, array('value' => 'sdk.simulator.types.PRODUCT_PAGE'),
-                array('config' => 'PAGANTIS_SIMULATOR_DISPLAY_TYPE'), array('%s'), array('%s'));
+            $wpdb->update(
+                $tableName,
+                array('value' => 'sdk.simulator.types.PRODUCT_PAGE'),
+                array('config' => 'PAGANTIS_SIMULATOR_DISPLAY_TYPE'),
+                array('%s'),
+                array('%s')
+            );
         }
 
         //Adapting to variable selector < v8.3.6
@@ -308,8 +340,13 @@ class WcPagantis
             "select * from $tableName where config='PAGANTIS_SIMULATOR_SELECTOR_VARIATION' and value='default'";
         $results          = $wpdb->get_results($query, ARRAY_A);
         if (count($results) == 0) {
-            $wpdb->update($tableName, array('value' => $variableSelector),
-                array('config' => 'PAGANTIS_SIMULATOR_SELECTOR_VARIATION'), array('%s'), array('%s'));
+            $wpdb->update(
+                $tableName,
+                array('value' => $variableSelector),
+                array('config' => 'PAGANTIS_SIMULATOR_SELECTOR_VARIATION'),
+                array('%s'),
+                array('%s')
+            );
         }
 
         $dbConfigs = $wpdb->get_results("select * from $tableName", ARRAY_A);
@@ -320,7 +357,7 @@ class WcPagantis
             $simpleDbConfigs[$config['config']] = $config['value'];
         }
         $newConfigs = array_diff_key($this->defaultConfigs, $simpleDbConfigs);
-        if ( ! empty($newConfigs)) {
+        if (! empty($newConfigs)) {
             foreach ($newConfigs as $key => $value) {
                 $wpdb->insert($tableName, array('config' => $key, 'value' => $value), array('%s', '%s'));
             }
@@ -329,12 +366,12 @@ class WcPagantis
         //Current plugin config: pagantis_public_key => New field --- public_key => Old field
         $settings = get_option('woocommerce_pagantis_settings');
 
-        if ( ! isset($settings['pagantis_public_key']) && $settings['public_key']) {
+        if (! isset($settings['pagantis_public_key']) && $settings['public_key']) {
             $settings['pagantis_public_key'] = $settings['public_key'];
             unset($settings['public_key']);
         }
 
-        if ( ! isset($settings['pagantis_private_key']) && $settings['secret_key']) {
+        if (! isset($settings['pagantis_private_key']) && $settings['secret_key']) {
             $settings['pagantis_private_key'] = $settings['secret_key'];
             unset($settings['secret_key']);
         }
@@ -400,7 +437,7 @@ class WcPagantis
      */
     public function addPagantisGateway($methods)
     {
-        if ( ! class_exists('WC_Payment_Gateway')) {
+        if (! class_exists('WC_Payment_Gateway')) {
             return $methods;
         }
 
@@ -420,7 +457,7 @@ class WcPagantis
     public function pagantisFilterGateways($methods)
     {
         $pagantis = new WcPagantisGateway();
-        if ( ! $pagantis->is_available()) {
+        if (! $pagantis->is_available()) {
             unset($methods['pagantis']);
         }
 
@@ -521,8 +558,13 @@ class WcPagantis
             if (count($_POST)) {
                 foreach ($_POST as $config => $value) {
                     if (isset($this->defaultConfigs[$config]) && $response['status'] == null) {
-                        $wpdb->update($tableName, array('value' => stripslashes($value)), array('config' => $config),
-                            array('%s'), array('%s'));
+                        $wpdb->update(
+                            $tableName,
+                            array('value' => stripslashes($value)),
+                            array('config' => $config),
+                            array('%s'),
+                            array('%s')
+                        );
                     } else {
                         $response['status'] = 400;
                         $response['result'] = 'Bad request';
@@ -647,7 +689,7 @@ class WcPagantis
     {
         if ($css_quantity_selector == 'default' || $css_quantity_selector == '') {
             $css_quantity_selector = $this->defaultConfigs['PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR'];
-        } elseif ( ! unserialize($css_quantity_selector)) { //in the case of a custom string selector, we keep it
+        } elseif (! unserialize($css_quantity_selector)) { //in the case of a custom string selector, we keep it
             $css_quantity_selector = serialize(array($css_quantity_selector));
         }
 
@@ -663,7 +705,7 @@ class WcPagantis
     {
         if ($css_price_selector == 'default' || $css_price_selector == '') {
             $css_price_selector = $this->defaultConfigs['PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR'];
-        } elseif ( ! unserialize($css_price_selector)) { //in the case of a custom string selector, we keep it
+        } elseif (! unserialize($css_price_selector)) { //in the case of a custom string selector, we keep it
             $css_price_selector = serialize(array($css_price_selector));
         }
 
@@ -682,7 +724,6 @@ class WcPagantis
         return (array_key_exists('custom_product_pagantis_promoted', $metaProduct)
                 && $metaProduct['custom_product_pagantis_promoted']['0'] === 'yes') ? 'true' : 'false';
     }
-
 }
 
 

--- a/config/install.sh
+++ b/config/install.sh
@@ -31,12 +31,16 @@ if [ ! -f app/etc/local.xml ]; then
         --admin_email=$WORDPRESS_ADMIN_EMAIL
 
     echo "SETTING WORDPRESS THEME"
-    wp --allow-root theme activate twentysixteen
+    #    wp --allow-root theme activate twentytwenty
 
     echo "INSTALLING WOOCOMMERCE"
     wp --allow-root plugin install wordpress-importer --activate
     wp --allow-root plugin install https://github.com/woocommerce/woocommerce/archive/$WOOCOMMERCE_VERSION.zip --activate
-    wp --allow-root import wp-content/plugins/woocommerce/sample-data/sample_products.xml --authors=create
+    echo "IMPORTING PRODUCTS TO WC WITH > /dev/null 2>&1"
+    wp --allow-root import wp-content/plugins/woocommerce/sample-data/sample_products.xml --authors=create > /dev/null 2>&1
+    echo "PRODUCTS IMPORTED WITH SUCCESS"
+
+    echo "ACTIVATING PAGANTIS PLUGIN"
     wp --allow-root plugin activate pagantis
 
 
@@ -60,6 +64,24 @@ if [ ! -f app/etc/local.xml ]; then
     wp --allow-root option update page_on_front	$SHOPIDPAGE
     wp --allow-root wc --user=admin shipping_zone_method create 0 --method_id=flat_rate
 
+    echo "ADDING DEVELOPMENT CONSTANTS"
+    wp --allow-root config set --add --type=constant WP_DEBUG_LOG true
+    wp --allow-root config set --add --type=constant WP_DEBUG_DISPLAY true
+    wp --allow-root config set --add --type=constant WP_DEBUG true
+    wp --allow-root config set --add --type=constant SAVEQUERIES true
+
+    echo "CHANGING WP TIMEZONE"
+    wp --allow-root option update timezone_string "Europe/Madrid"
+
+    echo "REMOVING WP CLUTTER"
+    wp --allow-root plugin delete hello
+    wp --allow-root plugin delete akismet
+
+    echo "REMOVING EXAMPLE PAGE"
+    wp --allow-root post delete 2
+
+    currentDateTimne=`date +"%D %T"`
+    echo "Current Server Time is $currentDateTimne"
     chown -R www-data:www-data /var/www/html/*
 fi
 

--- a/controllers/notifyController.php
+++ b/controllers/notifyController.php
@@ -460,7 +460,6 @@ class WcPagantisNotify extends WcPagantisGateway
                     $restSeconds
                 );
                 $this->insertLog(null, $logMessage);
-
             }
         }
     }

--- a/controllers/notifyController.php
+++ b/controllers/notifyController.php
@@ -21,7 +21,7 @@ if (!defined('ABSPATH')) {
 
 class WcPagantisNotify extends WcPagantisGateway
 {
-    /** Concurrency tablename  */
+    /** Concurrency table name  */
     const CONCURRENCY_TABLE = 'pagantis_concurrency';
 
     /** Seconds to expire a locked request */
@@ -60,7 +60,7 @@ class WcPagantisNotify extends WcPagantisGateway
     public function processInformation()
     {
         try {
-            require_once(__ROOT__.'/vendor/autoload.php');
+            require_once(PAGANTIS_ROOT_DIR.'/vendor/autoload.php');
             try {
                 if ($_SERVER['REQUEST_METHOD'] == 'GET' && $_GET['origin'] == 'notification') {
                     return $this->buildResponse();
@@ -138,7 +138,7 @@ class WcPagantisNotify extends WcPagantisGateway
     {
         global $wpdb;
         $this->checkDbTable();
-        $tableName = $wpdb->prefix.self::ORDERS_TABLE;
+        $tableName = $wpdb->prefix.self::ORDERS_PROCESSED_TABLE;
         $queryResult = $wpdb->get_row("select order_id from $tableName where id='".$this->woocommerceOrderId."'");
         $this->pagantisOrderId = $queryResult->order_id;
 
@@ -265,7 +265,7 @@ class WcPagantisNotify extends WcPagantisGateway
     private function checkDbTable()
     {
         global $wpdb;
-        $tableName = $wpdb->prefix.self::ORDERS_TABLE;
+        $tableName = $wpdb->prefix.self::ORDERS_PROCESSED_TABLE;
 
         if ($wpdb->get_var("SHOW TABLES LIKE '$tableName'") != $tableName) {
             $charset_collate = $wpdb->get_charset_collate();
@@ -352,7 +352,8 @@ class WcPagantisNotify extends WcPagantisGateway
             }
 
             $this->woocommerceOrder->add_order_note("Notification received via $this->origin");
-            $this->woocommerceOrder->reduce_order_stock();
+//            $this->woocommerceOrder->reduce_order_stock();
+            wc_maybe_reduce_stock_levels($this->woocommerceOrderId);
             $this->woocommerceOrder->save();
 
             $woocommerce->cart->empty_cart();
@@ -370,7 +371,7 @@ class WcPagantisNotify extends WcPagantisGateway
         global $wpdb;
 
         $this->checkDbTable();
-        $tableName = $wpdb->prefix.self::ORDERS_TABLE;
+        $tableName = $wpdb->prefix.self::ORDERS_PROCESSED_TABLE;
 
         $wpdb->update(
             $tableName,

--- a/controllers/paymentController.php
+++ b/controllers/paymentController.php
@@ -129,7 +129,7 @@ class WcPagantisGateway extends WC_Payment_Gateway
             'logo' => $this->icon,
             'settings' => $this->generate_settings_html($this->form_fields, false)
         );
-        wc_get_template('admin_header.php', $template_fields, '', $this->template_path);
+        wc_get_template('admin_header.php', $template_fields, '', PG_TEMPLATE_PATH);
     }
 
     /**

--- a/controllers/paymentController.php
+++ b/controllers/paymentController.php
@@ -501,7 +501,6 @@ class WcPagantisGateway extends WC_Payment_Gateway
                 'result'   => 'success',
                 'redirect' => $redirectUrl
             );
-
         } catch (Exception $e) {
             wc_add_notice(__('Payment error ', 'pagantis') . $e->getMessage(), 'error');
             return array();

--- a/controllers/paymentController.php
+++ b/controllers/paymentController.php
@@ -27,17 +27,17 @@ class WcPagantisGateway extends WC_Payment_Gateway
 {
     const METHOD_ID = "pagantis";
 
-    /** Orders tablename */
-    const ORDERS_TABLE = 'cart_process';
+    /** Orders table name */
+    const ORDERS_PROCESSED_TABLE = 'cart_process';
 
-    /** Concurrency tablename */
+    /** Concurrency table name */
     const LOGS_TABLE = 'pagantis_logs';
 
     const NOT_CONFIRMED = 'No se ha podido confirmar el pago';
 
     const CONFIG_TABLE = 'pagantis_config';
 
-    /** @var Array $extraConfig */
+    /** @var array $extraConfig */
     public $extraConfig;
 
     /** @var string $language */
@@ -65,7 +65,7 @@ class WcPagantisGateway extends WC_Payment_Gateway
         $this->icon = 'https://cdn.digitalorigin.com/assets/master/logos/pg-130x30.svg';
 
         //Panel form fields
-        $this->form_fields = include(plugin_dir_path(__FILE__).'../includes/settings-pagantis.php');//Panel options
+        $this->init_form_fields(); //Panel options
         $this->init_settings();
 
         $this->extraConfig = $this->getExtraConfig();
@@ -85,6 +85,16 @@ class WcPagantisGateway extends WC_Payment_Gateway
         add_action('woocommerce_api_wcpagantisgateway', array($this, 'pagantisNotification'));      //Json Notification
         add_filter('woocommerce_payment_complete_order_status', array($this,'pagantisCompleteStatus'), 10, 3);
         add_filter('load_textdomain_mofile', array($this, 'loadPagantisTranslation'), 10, 2);
+    }
+
+
+    /**
+     * Initialise Gateway Settings Form Fields
+     */
+    public function init_form_fields()
+    {
+
+        $this->form_fields = include(PAGANTIS_ROOT_DIR . '/includes/settings-pagantis.php');
     }
 
     /**
@@ -167,7 +177,7 @@ class WcPagantisGateway extends WC_Payment_Gateway
     public function pagantisReceiptPage($order_id)
     {
         try {
-            require_once(__ROOT__.'/vendor/autoload.php');
+            require_once(PAGANTIS_ROOT_DIR.'/vendor/autoload.php');
             global $woocommerce;
             $order = new WC_Order($order_id);
             $order->set_payment_method(ucfirst($this->id));
@@ -736,7 +746,7 @@ class WcPagantisGateway extends WC_Payment_Gateway
     {
         global $wpdb;
         $this->checkDbTable();
-        $tableName = $wpdb->prefix.self::ORDERS_TABLE;
+        $tableName = $wpdb->prefix.self::ORDERS_PROCESSED_TABLE;
 
         //Check if id exists
         $resultsSelect = $wpdb->get_results("select * from $tableName where id='$orderId'");
@@ -764,7 +774,7 @@ class WcPagantisGateway extends WC_Payment_Gateway
     private function checkDbTable()
     {
         global $wpdb;
-        $tableName = $wpdb->prefix.self::ORDERS_TABLE;
+        $tableName = $wpdb->prefix.self::ORDERS_PROCESSED_TABLE;
 
         if ($wpdb->get_var("SHOW TABLES LIKE '$tableName'") != $tableName) {
             $charset_collate = $wpdb->get_charset_collate();

--- a/generate.sh
+++ b/generate.sh
@@ -1,65 +1,215 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-while true; do
-    read -p "Do you wish to run dev or test [test|dev]? " devtest
-    case $devtest in
-        [dev]* ) container="woocommerce-dev";test=false; break;;
-        [test]* ) container="woocommerce-test";test=true; break;;
-        * ) echo "Please answer dev or test.";;
-    esac
-done
-while true; do
-    read -p "You have chosen to start ${container}, are you sure [y/n]? " yn
-    case $yn in
-        [Yy]* ) break;;
-        [Nn]* ) exit;;
-        * ) echo "Please answer yes or no.";;
-    esac
-done
-
-# Prepare environment and build package
-docker-compose down
-docker-compose up -d --build ${container}
-docker-compose up -d selenium
-npm install
-node_modules/.bin/grunt
-docker-compose exec ${container} curl -s https://getcomposer.org/installer | php
-docker-compose exec ${container} ./composer.phar install
-
-# Time to boot and install woocommerce
-sleep 80
 set -e
+# Output colorized strings
+# https://linux.101hacks.com/ps1-examples/prompt-color-using-tput/
+# Color codes:
+# 0 - black | 1 - red | 2 - green | 3 - yellow | 4 - blue | 5 - magenta | 6 - cyan | 7 - white
+output() {
+    local INDENT="  "
+    echo "$(tput setb 7)$(tput setaf "$1")$INDENT$2$(tput sgr0)"
+}
 
-export WOOCOMMERCE_TEST_ENV=${devtest}
-while true; do
-    read -p "Do you want to run full tests battery or only configure the module [full/configure/none]? " tests
-    case $tests in
-        [full]* ) break;;
-        [configure]* ) break;;
-        [none]* ) break;;
-        * ) echo "Please answer full, configure or none."; exit;;
-    esac
-done
+function check_requirements() {
+    local INDENT="  "
+    if [ "${BASH_VERSINFO:-0}" -lt 4 ]; then
+        output 1 "$INDENT [ERROR] Unmet requirements: Bash 4"
+        output 1 "$INDENT Your Bash version is $BASH_VERSION"
+        output 1 "$INDENT Exiting with error code 1" 1>&2
+        exit 1
+    fi
 
-if [ ! -z "$tests" ] && [ "$tests" != "none" ];
-then
-    vendor/bin/phpunit --group woocommerce3-basic
+    if ! [ -x "$(command -v curl)" ]; then
+        output 1 "$INDENT Error: curl is not installed." >&2
+        exit 1
+    fi
+    if ! [ -x "$(command -v docker)" ]; then
+        output 1 "$INDENT Error: docker is not installed." >&2
+        exit 1
+    fi
 
-    #Only for TEST environment. DEV environment is already installed
-    if [ $devtest = "test" ];
-    then
-        vendor/bin/phpunit --group woocommerce3-install
+    if ! [ -x "$(command -v docker-compose)" ]; then
+        output 1 "$INDENT Error: docker-compose is not installed." >&2
+        exit 1
+    fi
+}
+
+function type_of_var() {
+
+    local type_signature=$(declare -p "$1" 2 > /dev/null)
+
+    if [[ "$type_signature" =~ "declare --" ]]; then
+        printf "string"
+    elif [[ "$type_signature" =~ "declare -a" ]]; then
+        printf "array"
+    elif [[ "$type_signature" =~ "declare -A" ]]; then
+        printf "map"
     else
-        export WOOCOMMERCE_LANG=EN #in dev mode, woocommerce is installed in english
-        vendor/bin/phpunit --group woocommerce3-configure
+        printf "none"
     fi
 
-    if [ $tests = "full" ];
-    then
-        vendor/bin/phpunit --group woocommerce3-buy
-    fi
+}
+
+check_requirements
+shopt -s nocasematch
+
+
+if [[ "$@" -eq "f" ]];
+then
+    while [[ "$#" -eq 1 ]];
+    do
+        container="woocommerce-dev";
+        test=false;
+        fast_mode=true;
+        output 6 "FAST MODE enabled"
+        break;
+    done
 fi
 
-containerPort=$(docker container port ${container})
-PORT=$(sed  -e 's/.*://' <<< $containerPort)
-echo 'Build of Woocommerce complete: http://'${container}'.docker:'${PORT}
+if [ -z "${fast_mode}" ];
+then
+    while true; do
+        read -p "Do you wish to run dev or test [test|dev|f]? " devtest
+        case $devtest in
+            [dev]*) container="woocommerce-dev";
+            test=false;
+            break ;;
+            [f]*) container="woocommerce-dev";
+            test=false;
+            fast_mode=true;
+            output 6 "FAST MODE enabled"
+            break ;;
+            [test]*) container="woocommerce-test";
+            test=true;
+            break ;;
+            *) output 5 "Please answer dev or test." ;;
+        esac
+    done
+    while true; do
+        read -p "You have chosen to start ${container^^}, are you sure [y/n]? " yn
+        case $yn in
+            [Yy]*) break ;;
+            [Nn]*) exit ;;
+            *) output 5 "Please answer yes or no." ;;
+        esac
+    done
+fi
+# Prepare environment and build package
+echo
+output 6 "Removing previously built 🐳️containers"
+docker-compose down -v
+
+echo
+output 6 "Starting to build 🐳️containers"
+docker-compose up -d --build ${container}
+#containerLogPath=$(docker inspect --format='{{.LogPath}}' ${container})
+#touch ./docker/logs/${container}-logs.log
+#docker-compose logs  --raw --timestamps --no-color ${container} |& tee ./docker/logs/${container}-logs.log
+
+if [ -z "${fast_mode}" ];
+then
+    echo
+    output 6 "Starting selenium container"
+    echo
+    docker-compose up -d selenium
+    echo
+    output 6 "npm i"
+    echo
+    npm install
+    echo
+    output 6 "ZIPPING PLUGIN"
+    echo
+    node_modules/.bin/grunt
+fi
+
+echo
+output 6 "Installing composer in ${container^^}"
+docker-compose exec ${container} curl -s https://getcomposer.org/installer | php
+
+echo
+output 6 "Running composer install in ${container^^}"
+echo
+docker-compose exec ${container} ./composer.phar install --no-suggest
+
+SLEEP_TIME=40
+echo
+output 6 "SLEEPING ${SLEEP_TIME} SECONDS TO GIVE TIME TO "${container^^}" TO SPIN UP"
+sleep ${SLEEP_TIME}
+echo
+output 6 "CHECKING container STATUS"
+echo
+CONTAINER_PORT=$(docker container port ${container})
+PORT=$(sed -e 's/.*://' <<< ${CONTAINER_PORT})
+
+isContainerPaused=$(docker inspect --format='{{.State.Paused}}' ${container})
+isContainerDead=$(docker inspect --format='{{.State.Dead}}' ${container})
+isContainerRunning=$(docker inspect --format "{{.State.Running}}" ${container} 2> /dev/null)
+
+#set -vx
+RETURN=1
+while [[ "$RETURN" -ne "0" ]]; do
+    set +e
+    httpResponse=$(curl -sf -o /dev/null -w '%{response_code}' "http:/${container}.docker:${PORT}/wp-admin/admin.php?page=wc-status")
+    if [ "$httpResponse" -ne "302" ]; then
+        SLEEP_CYCLE=5
+        output 3 "Looks like the WooCommerce Install is not finished yet.. waiting ${SLEEP_CYCLE} more seconds"
+        sleep ${SLEEP_CYCLE}
+    else
+        echo
+        output 2 "(*・‿・)ノ⌒*:･ﾟ✧ 🎉"
+        output 2 "Build of Woocommerce complete -  Visit whichever url you prefer"
+        output 2 "- http://${container}.docker:${PORT}/wp-admin/"
+        output 2 "- http://${container}.docker:${PORT}/wp-admin/admin.php?page=wc-settings&tab=checkout&section=pagantis"
+        output 2 "- http://${container}.docker:${PORT}/wp-admin/admin.php?page=wc-status"
+        RETURN=0
+    fi
+    set -e
+    CONTAINER_STATUS=$(docker inspect --format='{{.State.Status}}' ${container})
+    CONTAINER_PID=$(docker inspect --format='{{.State.Pid}}' ${container})
+    CONTAINER_ERROR_MESSAGE=$(docker inspect --format='{{.State.Error}}' ${container})
+    if [ "$CONTAINER_PID" == "0" ] && [ "$isContainerRunning" != 'true' ];
+    then
+        echo
+        output 1 "$(date +'%Y-%m-%dT%H:%M:%S%z')]"
+        output 1 "${container} BUILD FAILED"
+        output 1 "CURRENT STATUS : ${CONTAINER_STATUS}"
+        output 1 "CONTAINER_EXIT_CODE : ${CONTAINER_PID}"
+        output 1 "ERROR MESSAGE : ${CONTAINER_ERROR_MESSAGE}"
+        exit 1
+    fi
+
+done
+if [ -z "${fast_mode}" ];
+then
+    export WOOCOMMERCE_TEST_ENV=${devtest}
+    while true; do
+        read -p "Do you want to run full tests battery or only configure the module [full/configure/none]? " tests
+        case $tests in
+            [full]*) break ;;
+            [configure]*) break ;;
+            [none]*) break ;;
+            *) output 5 "Please answer full, configure or none.";
+            exit ;;
+        esac
+    done
+
+    if [ ! -z "$tests" ] && [ "$tests" != "none" ];
+    then
+        vendor/bin/phpunit --group woocommerce3-basic
+
+        #Only for TEST environment. DEV environment is already installed
+        if [ $devtest = "test" ];
+        then
+            vendor/bin/phpunit --group woocommerce3-install
+        else
+            export WOOCOMMERCE_LANG=EN #in dev mode, woocommerce is installed in english
+            vendor/bin/phpunit --group woocommerce3-configure
+        fi
+
+        if [ $tests = "full" ];
+        then
+            vendor/bin/phpunit --group woocommerce3-buy
+        fi
+    fi
+
+fi

--- a/includes/class-pg-wc-logger.php
+++ b/includes/class-pg-wc-logger.php
@@ -1,0 +1,92 @@
+<?php
+
+
+defined('ABSPATH') || exit;
+
+/**
+ * Log all things!
+ *
+ * @since    8.3.8
+ * @version  1.0.0
+ */
+class PG_WC_Logger
+{
+
+    public static $logger;
+    const WC_LOG_FILENAME = PAGANTIS_PLUGIN_ID;
+
+    /**
+     * Utilize WC logger class
+     *
+     * @param      $message
+     * @param null $start_time
+     * @param null $end_time
+     *
+     * @version 1.0.0
+     * @since   8.3.8
+     */
+    public static function log($message, $start_time = null, $end_time = null)
+    {
+        if (! class_exists('WC_Logger')) {
+            return;
+        }
+
+        if (apply_filters('wc_pagantis_logging', true, $message)) {
+            if (empty(self::$logger)) {
+                self::$logger = wc_get_logger();
+            }
+        }
+
+        $settings = get_option('woocommerce_pagantis_settings');
+
+        if (empty($settings) || isset($settings['debug']) && 'yes' !== $settings['debug']) {
+            return;
+        }
+
+        if (! is_null($start_time)) {
+            $formatted_start_time = date_i18n(get_option('date_format') . ' g:ia', $start_time);
+            $end_time             = is_null($end_time) ? current_time('timestamp') : $end_time;
+            $formatted_end_time   = date_i18n(get_option('date_format') . ' g:ia', $end_time);
+            $elapsed_time         = round(abs($end_time - $start_time) / 60, 2);
+
+            $log_entry = "\n" . '====Pagantis Version: ' . PG_VERSION . '====' . "\n";
+            $log_entry .= '====Start Log ' . $formatted_start_time . '====' . "\n" . $message . "\n";
+            $log_entry .= '====End Log ' . $formatted_end_time . ' (' . $elapsed_time . ')====' . "\n\n";
+        } else {
+            $log_entry = "\n" . '====Pagantis Version: ' . PG_VERSION . '====' . "\n";
+            $log_entry .= '====Start Log====' . "\n" . wp_json_encode($message) . "\n" . '====End Log====' . "\n\n";
+        }
+
+        self::$logger->debug($log_entry, array('source' => self::WC_LOG_FILENAME));
+    }
+
+
+    /**
+     * @param      $message
+     * @param null $start_time
+     * @param null $end_time
+     */
+    public static function logToDB($message, $start_time = null, $end_time = null)
+    {
+        if (! class_exists('WC_Log_Handler_DB')) {
+            return;
+        }
+
+        if (apply_filters('wc_pagantis_logging_to_db', true, $message)) {
+            $handler = new WC_Log_Handler_DB();
+
+
+            $settings = get_option('woocommerce_pagantis_settings');
+
+            if (empty($settings) || isset($settings['debug']) && 'yes' !== $settings['debug']) {
+                return;
+            }
+            $handler->handle(
+                time(),
+                'debug',
+                wp_json_encode($message),
+                array('source' => self::WC_LOG_FILENAME)
+            );
+        }
+    }
+}

--- a/includes/class-pg-wc-remote-config.php
+++ b/includes/class-pg-wc-remote-config.php
@@ -1,0 +1,82 @@
+<?php
+
+
+class PG_Merchant_Config
+{
+
+
+    /**
+     * @return array
+     */
+    public static function getDefaultConfigArray()
+    {
+        return array(
+            'PAGANTIS_TITLE'                           => 'Pago en cuotas',
+            'PAGANTIS_SIMULATOR_DISPLAY_TYPE'          => 'sdk.simulator.types.PRODUCT_PAGE',
+            'PAGANTIS_SIMULATOR_DISPLAY_TYPE_CHECKOUT' => 'sdk.simulator.types.CHECKOUT_PAGE',
+            'PAGANTIS_SIMULATOR_DISPLAY_SKIN'          => 'sdk.simulator.skins.BLUE',
+            'PAGANTIS_SIMULATOR_DISPLAY_POSITION'      => 'hookDisplayProductButtons',
+            'PAGANTIS_SIMULATOR_START_INSTALLMENTS'    => 3,
+            'PAGANTIS_SIMULATOR_MAX_INSTALLMENTS'      => 12,
+            'PAGANTIS_SIMULATOR_CSS_POSITION_SELECTOR' => 'default',
+            'PAGANTIS_SIMULATOR_DISPLAY_CSS_POSITION'  => 'sdk.simulator.positions.INNER',
+            'PAGANTIS_SIMULATOR_CSS_PRICE_SELECTOR'    => 'a:3:{i:0;s:48:"div.summary *:not(del)>.woocommerce-Price-amount";i:1;s:54:"div.entry-summary *:not(del)>.woocommerce-Price-amount";i:2;s:36:"*:not(del)>.woocommerce-Price-amount";}',
+            'PAGANTIS_SIMULATOR_CSS_QUANTITY_SELECTOR' => 'a:2:{i:0;s:22:"div.quantity input.qty";i:1;s:18:"div.quantity>input";}',
+            'PAGANTIS_FORM_DISPLAY_TYPE'               => 0,
+            'PAGANTIS_DISPLAY_MIN_AMOUNT'              => 1,
+            'PAGANTIS_DISPLAY_MAX_AMOUNT'              => 0,
+            'PAGANTIS_URL_OK'                          => '',
+            'PAGANTIS_URL_KO'                          => '',
+            'PAGANTIS_ALLOWED_COUNTRIES'               => 'a:3:{i:0;s:2:"es";i:1;s:2:"it";i:2;s:2:"fr";}',
+            'PAGANTIS_PROMOTION_EXTRA'                 => '<p>Finance this product <span class="pg-no-interest">without interest!</span></p>',
+            'PAGANTIS_SIMULATOR_THOUSANDS_SEPARATOR'   => '.',
+            'PAGANTIS_SIMULATOR_DECIMAL_SEPARATOR'     => ',',
+            'PAGANTIS_SIMULATOR_DISPLAY_SITUATION'     => 'default',
+            'PAGANTIS_SIMULATOR_SELECTOR_VARIATION'    => 'default'
+        );
+    }
+
+    /**
+     * Get extra config from WP DB
+     *
+     * @return array
+     * @global wpdb $wpdb WordPress database abstraction object.
+     */
+    public static function getExtraConfig()
+    {
+        global $wpdb;
+        $tableName = $wpdb->prefix . PG_CONFIG_TABLE_NAME;
+        $response  = array();
+        $dbResult  = $wpdb->get_results("SELECT config, value FROM $tableName", ARRAY_A);
+        foreach ($dbResult as $value) {
+            $response[$value['config']] = $value['value'];
+        }
+
+        return $response;
+    }
+
+    /**
+     * Returns config value
+     * @param      $key
+     *
+     * @return mixed
+     */
+    public static function getValueOfKey($key)
+    {
+        $config = self::getDefaultConfigArray();
+        $value  = maybe_unserialize($config[$key]);
+
+        return $value;
+    }
+
+
+    /**
+     * @return mixed
+     */
+    public static function getAllowedCountriesSerialized()
+    {
+        $allowedCountries = self::getValueOfKey('PAGANTIS_ALLOWED_COUNTRIES');
+
+        return $allowedCountries;
+    }
+}

--- a/includes/settings-pagantis.php
+++ b/includes/settings-pagantis.php
@@ -1,19 +1,16 @@
 <?php
 
-if (!defined('ABSPATH')) {
+if (! defined('ABSPATH')) {
     exit;
 }
 
-/**
- * Settings for Pagantis Gateway.
- */
-return array(
-    'enabled' => array(
-        'title'       => __('Activate the module', 'pagantis'),
-        'type'        => 'checkbox',
-        'default'     => 'yes'
+$settings_array = array(
+    'enabled'              => array(
+        'title'   => __('Activate the module', 'pagantis'),
+        'type'    => 'checkbox',
+        'default' => 'yes'
     ),
-    'pagantis_public_key' => array(
+    'pagantis_public_key'  => array(
         'title'       => __('Public Key', 'pagantis'),
         'type'        => 'text',
         'description' => __('MANDATORY. You can get in your pagantis profile', 'pagantis')
@@ -23,9 +20,33 @@ return array(
         'type'        => 'text',
         'description' => __('MANDATORY. You can get in your pagantis profile', 'pagantis')
     ),
-    'simulator' => array(
-        'title'       => __('Product simulator', 'pagantis'),
-        'type'        => 'checkbox',
-        'default'     => 'yes'
+    'simulator'            => array(
+        'title'   => __('Product simulator', 'pagantis'),
+        'type'    => 'checkbox',
+        'default' => 'yes'
     )
 );
+$logsUrl        = esc_url(add_query_arg(
+    'log_file',
+    wc_get_log_file_name(PAGANTIS_PLUGIN_ID),
+    admin_url('admin.php?page=wc-status&tab=logs')
+));
+if (in_array(strtolower((string)WP_DEBUG_LOG), array('true', '1'), true)) {
+    $settings_array['debug'] = array(
+        'title'       => __('Debug log', 'woocommerce'),
+        'type'        => 'checkbox',
+        'label'       => __('Enable logging', 'woocommerce'),
+        'default'     => 'yes',
+        'desc_tip'    => false,
+        /* translators: %s: URL */
+        'description' => sprintf(__(
+            '<div class="woocommerce-info"> <p>Log Pagantis events to troubleshoot. </p><p> Log Location %s </p>
+                    <p> <a href="%s">You can also see the logs in this menu</a> </p>
+                    <p>Note: this may log personal information.</p> 
+                    <p>We recommend using this for debugging purposes only and deleting the logs when finished.</p></div>',
+            'woocommerce'
+        ), '<code>' . wc_get_log_file_name(PAGANTIS_PLUGIN_ID) . '</code>', $logsUrl)
+    );
+}
+
+return $settings_array;

--- a/includes/settings-pagantis.php
+++ b/includes/settings-pagantis.php
@@ -1,6 +1,6 @@
 <?php
 
-if (! defined('ABSPATH')) {
+if ( ! defined('ABSPATH')) {
     exit;
 }
 
@@ -26,11 +26,7 @@ $settings_array = array(
         'default' => 'yes'
     )
 );
-$logsUrl        = esc_url(add_query_arg(
-    'log_file',
-    wc_get_log_file_name(PAGANTIS_PLUGIN_ID),
-    admin_url('admin.php?page=wc-status&tab=logs')
-));
+
 if (in_array(strtolower((string)WP_DEBUG_LOG), array('true', '1'), true)) {
     $settings_array['debug'] = array(
         'title'       => __('Debug log', 'woocommerce'),
@@ -39,14 +35,15 @@ if (in_array(strtolower((string)WP_DEBUG_LOG), array('true', '1'), true)) {
         'default'     => 'yes',
         'desc_tip'    => false,
         /* translators: %s: URL */
-        'description' => sprintf(__(
-            '<div class="woocommerce-info"> <p>Log Pagantis events to troubleshoot. </p><p> Log Location %s </p>
-                    <p> <a href="%s">You can also see the logs in this menu</a> </p>
+        'description' => sprintf(__('<div class="woocommerce-info"> <p>Log Pagantis events to troubleshoot. </p><p> Log Location %s </p>
+            <p><a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="%s">You can also see the logs in this menu</a></p>
                     <p>Note: this may log personal information.</p> 
                     <p>We recommend using this for debugging purposes only and deleting the logs when finished.</p></div>',
-            'woocommerce'
-        ), '<code>' . wc_get_log_file_name(PAGANTIS_PLUGIN_ID) . '</code>', $logsUrl)
+            'woocommerce'), '<code>' . wc_get_log_file_name(PAGANTIS_PLUGIN_ID) . '</code>',
+            esc_url(add_query_arg('log_file', wc_get_log_file_name(PAGANTIS_PLUGIN_ID),
+                admin_url('admin.php?page=wc-status&tab=logs'))))
     );
 }
+
 
 return $settings_array;

--- a/includes/settings-pagantis.php
+++ b/includes/settings-pagantis.php
@@ -1,6 +1,6 @@
 <?php
 
-if ( ! defined('ABSPATH')) {
+if (! defined('ABSPATH')) {
     exit;
 }
 
@@ -35,13 +35,21 @@ if (in_array(strtolower((string)WP_DEBUG_LOG), array('true', '1'), true)) {
         'default'     => 'yes',
         'desc_tip'    => false,
         /* translators: %s: URL */
-        'description' => sprintf(__('<div class="woocommerce-info"> <p>Log Pagantis events to troubleshoot. </p><p> Log Location %s </p>
+        'description' => sprintf(
+            __(
+                '<div class="woocommerce-info"> <p>Log Pagantis events to troubleshoot. </p><p> Log Location %s </p>
             <p><a class="woocommerce-BlankState-cta button-primary button" target="_blank" href="%s">You can also see the logs in this menu</a></p>
                     <p>Note: this may log personal information.</p> 
                     <p>We recommend using this for debugging purposes only and deleting the logs when finished.</p></div>',
-            'woocommerce'), '<code>' . wc_get_log_file_name(PAGANTIS_PLUGIN_ID) . '</code>',
-            esc_url(add_query_arg('log_file', wc_get_log_file_name(PAGANTIS_PLUGIN_ID),
-                admin_url('admin.php?page=wc-status&tab=logs'))))
+                'woocommerce'
+            ),
+            '<code>' . wc_get_log_file_name(PAGANTIS_PLUGIN_ID) . '</code>',
+            esc_url(add_query_arg(
+                'log_file',
+                wc_get_log_file_name(PAGANTIS_PLUGIN_ID),
+                admin_url('admin.php?page=wc-status&tab=logs')
+            ))
+        )
     );
 }
 

--- a/templates/admin_header.php
+++ b/templates/admin_header.php
@@ -1,5 +1,5 @@
 <img id="pagantis_logo" src="<?php echo esc_url($logo); ?>" />
-<h3><?php echo $panel_header; ?></h3>
+<!--<h3>--><?php //echo $panel_header; ?><!--</h3>-->
 <p> <?php echo $panel_description; ?></p>
 <p><a href="https://bo.pagantis.com" target="_blank" class="button button-primary">
         <?php echo $button1_label; ?></a>

--- a/templates/product_simulator.php
+++ b/templates/product_simulator.php
@@ -1,5 +1,6 @@
 <script>
-    function findPriceSelector() {
+    function findPriceSelector()
+    {
         var priceSelectors = <?php echo json_encode($priceSelector);?>;
         return priceSelectors.find(function (candidateSelector) {
             var priceDOM = document.querySelector(candidateSelector);
@@ -8,7 +9,8 @@
 
     }
 
-    function findPositionSelector() {
+    function findPositionSelector()
+    {
         var positionSelector = '<?php echo $positionSelector;?>';
         if (positionSelector === 'default') {
             positionSelector = '.pagantisSimulator';
@@ -17,11 +19,12 @@
         return positionSelector;
     }
 
-    function findQuantitySelector() {
+    function findQuantitySelector()
+    {
         var quantitySelectors = <?php echo json_encode($quantitySelector);?>;
-        return quantitySelectors.find(function (candidateSelector) {
+        return quantitySelectors.find(function(candidateSelector) {
             var priceDOM = document.querySelector(candidateSelector);
-            return (priceDOM != null);
+            return (priceDOM != null );
         });
     }
 
@@ -34,7 +37,7 @@
         var simulatorLoaded = false;
         var positionSelector = findPositionSelector();
         var pgDiv = document.querySelectorAll(positionSelector);
-        if (pgDiv.length > 0 && typeof window.WCSimulatorId != 'undefined') {
+        if (pgDiv.length > 0 && typeof window.WCSimulatorId!='undefined') {
             var pgElement = pgDiv[0];
             if (pgElement.innerHTML != '') {
                 simulatorLoaded = true;
@@ -43,7 +46,8 @@
         return simulatorLoaded;
     }
 
-    function findDestinationSim() {
+    function findDestinationSim()
+    {
         var destinationSim = '<?php echo $finalDestination;?>';
         if (destinationSim === 'default' || destinationSim == '') {
             destinationSim = 'woocommerce-product-details__short-description';
@@ -52,15 +56,16 @@
         return destinationSim;
     }
 
-    function moveToPrice() {
+    function moveToPrice()
+    {
         if ('<?php echo $simulator_type; ?>' === 'sdk.simulator.types.SELECTABLE_TEXT_CUSTOM'
-            || '<?php echo $simulator_type; ?>' === 'sdk.simulator.types.PRODUCT_PAGE') {
+          ||  '<?php echo $simulator_type; ?>' === 'sdk.simulator.types.PRODUCT_PAGE') {
             var simnode = document.querySelector(findPositionSelector());
 
             var detailnode = document.getElementsByClassName(findDestinationSim());
             detailnode = detailnode['0'];
 
-            detailnode.parentNode.insertBefore(simnode, detailnode)
+            detailnode.parentNode.insertBefore(simnode,detailnode)
         }
     }
 
@@ -69,12 +74,15 @@
         return (window.attempts > 4)
     }
 
-    function loadSimulatorPagantis() {
-        if (typeof pgSDK == 'undefined') {
+    function loadSimulatorPagantis()
+    {
+        if(typeof pgSDK == 'undefined')
+        {
             return false;
         }
 
-        if (checkAttempts() || checkSimulatorContent()) {
+        if (checkAttempts() || checkSimulatorContent())
+        {
             return finishInterval();
         }
 
@@ -95,12 +103,12 @@
             locale: locale,
             country: country,
             itemAmountSelector: priceSelector,
-            amountParserConfig: {
+            amountParserConfig :  {
                 thousandSeparator: '<?php echo $thousandSeparator;?>',
                 decimalSeparator: '<?php echo $decimalSeparator;?>'
             },
-            numInstalments: '<?php echo $pagantisQuotesStart;?>',
-            skin: <?php echo $pagantisSimulatorSkin;?>,
+            numInstalments : '<?php echo $pagantisQuotesStart;?>',
+            skin : <?php echo $pagantisSimulatorSkin;?>,
             position: <?php echo $pagantisSimulatorPosition;?>
         };
 
@@ -111,7 +119,8 @@
 
         if (typeof window.pgSDK != 'undefined') {
             window.WCSimulatorId = window.pgSDK.simulator.init(simulator_options);
-            if (window.WCSimulatorId != '') {
+            if (window.WCSimulatorId!='')
+            {
                 moveToPrice();
             }
 
@@ -125,16 +134,20 @@
     }, 2000);
 
     window.lastPrice = '';
-
-    function updateSimulator() {
-        if (window.WCSimulatorId != '') {
+    function updateSimulator()
+    {
+        if (window.WCSimulatorId != '')
+        {
             var updateSelector = '<?php echo $variationSelector;?>';
 
             var productType = '<?php echo $productType;?>';
 
-            if (updateSelector == 'default' || updateSelector === '' || productType !== 'variable') {
+            if (updateSelector == 'default' || updateSelector === '' || productType!=='variable')
+            {
                 clearInterval(window.variationInterval);
-            } else {
+            }
+            else
+            {
                 var priceDOM = document.querySelector(updateSelector);
                 if (priceDOM != null) {
                     var newPrice = priceDOM.innerText;
@@ -155,7 +168,7 @@
 
 </script>
 <style>
-    .pg-no-interest {
+    .pg-no-interest{
         color: #00c1d5
     }
 </style>
@@ -163,8 +176,5 @@
 if ($promoted == 'true') {
     echo $promotedMessage;
 }
-require PG_INCLUDES_PATH . 'class-pg-wc-logger.php';
-PG_WC_Logger::log($quantitySelector);
 ?>
-<br/>
-<div class="pagantisSimulator"></div><br/><br/>
+<br/><div class="pagantisSimulator"></div><br/><br/>

--- a/templates/product_simulator.php
+++ b/templates/product_simulator.php
@@ -1,16 +1,14 @@
 <script>
-    function findPriceSelector()
-    {
+    function findPriceSelector() {
         var priceSelectors = <?php echo json_encode($priceSelector);?>;
-        return priceSelectors.find(function(candidateSelector) {
+        return priceSelectors.find(function (candidateSelector) {
             var priceDOM = document.querySelector(candidateSelector);
-            return (priceDOM != null );
+            return (priceDOM != null);
         });
 
     }
 
-    function findPositionSelector()
-    {
+    function findPositionSelector() {
         var positionSelector = '<?php echo $positionSelector;?>';
         if (positionSelector === 'default') {
             positionSelector = '.pagantisSimulator';
@@ -19,12 +17,11 @@
         return positionSelector;
     }
 
-    function findQuantitySelector()
-    {
+    function findQuantitySelector() {
         var quantitySelectors = <?php echo json_encode($quantitySelector);?>;
-        return quantitySelectors.find(function(candidateSelector) {
+        return quantitySelectors.find(function (candidateSelector) {
             var priceDOM = document.querySelector(candidateSelector);
-            return (priceDOM != null );
+            return (priceDOM != null);
         });
     }
 
@@ -37,7 +34,7 @@
         var simulatorLoaded = false;
         var positionSelector = findPositionSelector();
         var pgDiv = document.querySelectorAll(positionSelector);
-        if (pgDiv.length > 0 && typeof window.WCSimulatorId!='undefined') {
+        if (pgDiv.length > 0 && typeof window.WCSimulatorId != 'undefined') {
             var pgElement = pgDiv[0];
             if (pgElement.innerHTML != '') {
                 simulatorLoaded = true;
@@ -46,8 +43,7 @@
         return simulatorLoaded;
     }
 
-    function findDestinationSim()
-    {
+    function findDestinationSim() {
         var destinationSim = '<?php echo $finalDestination;?>';
         if (destinationSim === 'default' || destinationSim == '') {
             destinationSim = 'woocommerce-product-details__short-description';
@@ -56,16 +52,15 @@
         return destinationSim;
     }
 
-    function moveToPrice()
-    {
+    function moveToPrice() {
         if ('<?php echo $simulator_type; ?>' === 'sdk.simulator.types.SELECTABLE_TEXT_CUSTOM'
-          ||  '<?php echo $simulator_type; ?>' === 'sdk.simulator.types.PRODUCT_PAGE') {
+            || '<?php echo $simulator_type; ?>' === 'sdk.simulator.types.PRODUCT_PAGE') {
             var simnode = document.querySelector(findPositionSelector());
 
             var detailnode = document.getElementsByClassName(findDestinationSim());
             detailnode = detailnode['0'];
 
-            detailnode.parentNode.insertBefore(simnode,detailnode)
+            detailnode.parentNode.insertBefore(simnode, detailnode)
         }
     }
 
@@ -74,15 +69,12 @@
         return (window.attempts > 4)
     }
 
-    function loadSimulatorPagantis()
-    {
-        if(typeof pgSDK == 'undefined')
-        {
+    function loadSimulatorPagantis() {
+        if (typeof pgSDK == 'undefined') {
             return false;
         }
 
-        if (checkAttempts() || checkSimulatorContent())
-        {
+        if (checkAttempts() || checkSimulatorContent()) {
             return finishInterval();
         }
 
@@ -103,12 +95,12 @@
             locale: locale,
             country: country,
             itemAmountSelector: priceSelector,
-            amountParserConfig :  {
+            amountParserConfig: {
                 thousandSeparator: '<?php echo $thousandSeparator;?>',
                 decimalSeparator: '<?php echo $decimalSeparator;?>'
             },
-            numInstalments : '<?php echo $pagantisQuotesStart;?>',
-            skin : <?php echo $pagantisSimulatorSkin;?>,
+            numInstalments: '<?php echo $pagantisQuotesStart;?>',
+            skin: <?php echo $pagantisSimulatorSkin;?>,
             position: <?php echo $pagantisSimulatorPosition;?>
         };
 
@@ -119,8 +111,7 @@
 
         if (typeof window.pgSDK != 'undefined') {
             window.WCSimulatorId = window.pgSDK.simulator.init(simulator_options);
-            if (window.WCSimulatorId!='')
-            {
+            if (window.WCSimulatorId != '') {
                 moveToPrice();
             }
 
@@ -134,20 +125,16 @@
     }, 2000);
 
     window.lastPrice = '';
-    function updateSimulator()
-    {
-        if (window.WCSimulatorId != '')
-        {
+
+    function updateSimulator() {
+        if (window.WCSimulatorId != '') {
             var updateSelector = '<?php echo $variationSelector;?>';
 
             var productType = '<?php echo $productType;?>';
 
-            if (updateSelector == 'default' || updateSelector === '' || productType!=='variable')
-            {
+            if (updateSelector == 'default' || updateSelector === '' || productType !== 'variable') {
                 clearInterval(window.variationInterval);
-            }
-            else
-            {
+            } else {
                 var priceDOM = document.querySelector(updateSelector);
                 if (priceDOM != null) {
                     var newPrice = priceDOM.innerText;
@@ -168,7 +155,7 @@
 
 </script>
 <style>
-    .pg-no-interest{
+    .pg-no-interest {
         color: #00c1d5
     }
 </style>
@@ -176,5 +163,8 @@
 if ($promoted == 'true') {
     echo $promotedMessage;
 }
+require PG_INCLUDES_PATH . 'class-pg-wc-logger.php';
+PG_WC_Logger::log($quantitySelector);
 ?>
-<br/><div class="pagantisSimulator"></div><br/><br/>
+<br/>
+<div class="pagantisSimulator"></div><br/><br/>


### PR DESCRIPTION
Just made some small non breaking changes to make it easy to refactor progressively in the future.

- I[f WP_DEBUG_LOG is true logging to WC-LOGS folder is activated by default and option is visible in plugin settings](https://github.com/pagantis/woocommerce/blob/5e394ca30b6c5653f82bd5e204e78aa1fb0a6e1e/includes/settings-pagantis.php#L30)
- added  [PG_WC_Logger Controller](https://github.com/pagantis/woocommerce/blob/int-963-rev/includes/class-pg-wc-logger.php) 

- Improved [generate.sh](https://github.com/pagantis/woocommerce/blob/int-963-rev/generate.sh) doing ./generate.sh f will now start in "fast_mode 🚀🚀🚀"

- generate.sh script will only display success message when WooCommerce install is finished

- improvements have been made to [install.sh](https://github.com/pagantis/woocommerce/blob/int-963-rev/config/install.sh) to produce less output  to terminal
- twentytwenty is installed and active by default on WP 5.3.2 and twentysixteen has been dropped
- [added  development constants in wp-config.php with wp-cli ](https://github.com/pagantis/woocommerce/blob/int-963-rev/config/install.sh#L67)
- [changed instance timezone to make is easier to troubleshoot](https://github.com/pagantis/woocommerce/blob/5e394ca30b6c5653f82bd5e204e78aa1fb0a6e1e/config/install.sh#L74)

- [Dockerfile apt and docker-php-ext is now more quiet](https://github.com/pagantis/woocommerce/blob/5e394ca30b6c5653f82bd5e204e78aa1fb0a6e1e/Dockerfile#L20)